### PR TITLE
MTDSA-479 Renamed BaseDomain to JsMarshaller

### DIFF
--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/SourceHandler.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/SourceHandler.scala
@@ -25,7 +25,7 @@ import uk.gov.hmrc.selfassessmentapi.repositories.SourceRepository
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-abstract class SourceHandler[T](domain: BaseDomain[T], val listName: String) {
+abstract class SourceHandler[T](domain: JsMarshaller[T], val listName: String) {
 
   val repository: SourceRepository[T]
   implicit val reads = domain.reads

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/SourceHandler.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/SourceHandler.scala
@@ -25,11 +25,11 @@ import uk.gov.hmrc.selfassessmentapi.repositories.SourceRepository
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-abstract class SourceHandler[T](jsMarshaller: JsMarshaller[T], val listName: String) {
+abstract class SourceHandler[T](jsonMarshaller: JsonMarshaller[T], val listName: String) {
 
   val repository: SourceRepository[T]
-  implicit val reads = jsMarshaller.reads
-  implicit val writes = jsMarshaller.writes
+  implicit val reads = jsonMarshaller.reads
+  implicit val writes = jsonMarshaller.writes
 
   def create(saUtr: SaUtr, taxYear: TaxYear, jsValue: JsValue) = {
     validate[T, String](jsValue) {

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/SourceHandler.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/SourceHandler.scala
@@ -25,11 +25,11 @@ import uk.gov.hmrc.selfassessmentapi.repositories.SourceRepository
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-abstract class SourceHandler[T](domain: JsMarshaller[T], val listName: String) {
+abstract class SourceHandler[T](jsMarshaller: JsMarshaller[T], val listName: String) {
 
   val repository: SourceRepository[T]
-  implicit val reads = domain.reads
-  implicit val writes = domain.writes
+  implicit val reads = jsMarshaller.reads
+  implicit val writes = jsMarshaller.writes
 
   def create(saUtr: SaUtr, taxYear: TaxYear, jsValue: JsValue) = {
     validate[T, String](jsValue) {

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/SummaryHandler.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/SummaryHandler.scala
@@ -20,15 +20,15 @@ import play.api.libs.json.Json._
 import play.api.libs.json._
 import uk.gov.hmrc.domain.SaUtr
 import uk.gov.hmrc.selfassessmentapi.controllers.controllers._
-import uk.gov.hmrc.selfassessmentapi.domain.{JsMarshaller, _}
+import uk.gov.hmrc.selfassessmentapi.domain.{JsonMarshaller, _}
 import uk.gov.hmrc.selfassessmentapi.repositories.SummaryRepository
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-case class SummaryHandler[T](repository: SummaryRepository[T], jsMarshaller: JsMarshaller[T], listName: String) {
+case class SummaryHandler[T](repository: SummaryRepository[T], jsonMarshaller: JsonMarshaller[T], listName: String) {
 
-  implicit val reads: Reads[T] = jsMarshaller.reads
-  implicit val writes: Writes[T] = jsMarshaller.writes
+  implicit val reads: Reads[T] = jsonMarshaller.reads
+  implicit val writes: Writes[T] = jsonMarshaller.writes
 
   def create(saUtr: SaUtr, taxYear: TaxYear, sourceId: SourceId, jsValue: JsValue) =
     validate[T, Option[String]](jsValue) {

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/SummaryHandler.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/SummaryHandler.scala
@@ -25,10 +25,10 @@ import uk.gov.hmrc.selfassessmentapi.repositories.SummaryRepository
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-case class SummaryHandler[T](repository: SummaryRepository[T], domain: JsMarshaller[T], listName: String) {
+case class SummaryHandler[T](repository: SummaryRepository[T], jsMarshaller: JsMarshaller[T], listName: String) {
 
-  implicit val reads: Reads[T] = domain.reads
-  implicit val writes: Writes[T] = domain.writes
+  implicit val reads: Reads[T] = jsMarshaller.reads
+  implicit val writes: Writes[T] = jsMarshaller.writes
 
   def create(saUtr: SaUtr, taxYear: TaxYear, sourceId: SourceId, jsValue: JsValue) =
     validate[T, Option[String]](jsValue) {

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/SummaryHandler.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/SummaryHandler.scala
@@ -20,12 +20,12 @@ import play.api.libs.json.Json._
 import play.api.libs.json._
 import uk.gov.hmrc.domain.SaUtr
 import uk.gov.hmrc.selfassessmentapi.controllers.controllers._
-import uk.gov.hmrc.selfassessmentapi.domain.{BaseDomain, _}
+import uk.gov.hmrc.selfassessmentapi.domain.{JsMarshaller, _}
 import uk.gov.hmrc.selfassessmentapi.repositories.SummaryRepository
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-case class SummaryHandler[T](repository: SummaryRepository[T], domain: BaseDomain[T], listName: String) {
+case class SummaryHandler[T](repository: SummaryRepository[T], domain: JsMarshaller[T], listName: String) {
 
   implicit val reads: Reads[T] = domain.reads
   implicit val writes: Writes[T] = domain.writes

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/CountryCodes.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/CountryCodes.scala
@@ -42,7 +42,7 @@ object CountryCodes extends Enumeration {
 
 case class CountryAndAmount(countryCode: CountryCode, amount: BigDecimal)
 
-object CountryAndAmount extends JsMarshaller[CountryAndAmount] {
+object CountryAndAmount extends JsonMarshaller[CountryAndAmount] {
   override implicit val writes = Json.writes[CountryAndAmount]
   override implicit val reads = (
     (__ \ "countryCode").read[CountryCode] and

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/CountryCodes.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/CountryCodes.scala
@@ -42,7 +42,7 @@ object CountryCodes extends Enumeration {
 
 case class CountryAndAmount(countryCode: CountryCode, amount: BigDecimal)
 
-object CountryAndAmount extends BaseDomain[CountryAndAmount] {
+object CountryAndAmount extends JsMarshaller[CountryAndAmount] {
   override implicit val writes = Json.writes[CountryAndAmount]
   override implicit val reads = (
     (__ \ "countryCode").read[CountryCode] and

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/JsMarshaller.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/JsMarshaller.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.selfassessmentapi.domain
 
 import play.api.libs.json.{Reads, Writes}
 
-trait BaseDomain[T] {
+trait JsMarshaller[T] {
   val writes : Writes[T]
   val reads : Reads[T]
   def example(id: Option[String] = None) : T

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/JsonMarshaller.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/JsonMarshaller.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.selfassessmentapi.domain
 
 import play.api.libs.json.{Reads, Writes}
 
-trait JsMarshaller[T] {
+trait JsonMarshaller[T] {
   val writes : Writes[T]
   val reads : Reads[T]
   def example(id: Option[String] = None) : T

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/TaxYearProperties.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/TaxYearProperties.scala
@@ -33,7 +33,7 @@ case class TaxYearProperties(id: Option[String] = None, pensionContributions: Op
                              taxRefundedOrSetOff: Option[TaxRefundedOrSetOff] = None,
                              childBenefit: Option[ChildBenefit] = None)
 
-object TaxYearProperties extends JsMarshaller[TaxYearProperties] {
+object TaxYearProperties extends JsonMarshaller[TaxYearProperties] {
 
   override implicit val writes = Json.writes[TaxYearProperties]
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/TaxYearProperties.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/TaxYearProperties.scala
@@ -33,7 +33,7 @@ case class TaxYearProperties(id: Option[String] = None, pensionContributions: Op
                              taxRefundedOrSetOff: Option[TaxRefundedOrSetOff] = None,
                              childBenefit: Option[ChildBenefit] = None)
 
-object TaxYearProperties extends BaseDomain[TaxYearProperties] {
+object TaxYearProperties extends JsMarshaller[TaxYearProperties] {
 
   override implicit val writes = Json.writes[TaxYearProperties]
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/blindperson/BlindPerson.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/blindperson/BlindPerson.scala
@@ -23,14 +23,14 @@ import play.api.libs.json._
 import uk.gov.hmrc.selfassessmentapi.domain.CountryCodes.{apply => _}
 import uk.gov.hmrc.selfassessmentapi.domain.ErrorCode._
 import uk.gov.hmrc.selfassessmentapi.domain.UkCountryCodes.{apply => _, _}
-import uk.gov.hmrc.selfassessmentapi.domain.{JsMarshaller, _}
+import uk.gov.hmrc.selfassessmentapi.domain.{JsonMarshaller, _}
 
 case class BlindPerson(country: Option[UkCountryCode] = None,
                        registrationAuthority: Option[String] = None,
                        spouseSurplusAllowance: Option[BigDecimal] = None,
                        wantSpouseToUseSurplusAllowance: Option[Boolean] = None)
 
-object BlindPerson extends JsMarshaller[BlindPerson] {
+object BlindPerson extends JsonMarshaller[BlindPerson] {
 
 
   override implicit val writes = Json.writes[BlindPerson]

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/blindperson/BlindPerson.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/blindperson/BlindPerson.scala
@@ -23,14 +23,14 @@ import play.api.libs.json._
 import uk.gov.hmrc.selfassessmentapi.domain.CountryCodes.{apply => _}
 import uk.gov.hmrc.selfassessmentapi.domain.ErrorCode._
 import uk.gov.hmrc.selfassessmentapi.domain.UkCountryCodes.{apply => _, _}
-import uk.gov.hmrc.selfassessmentapi.domain.{BaseDomain, _}
+import uk.gov.hmrc.selfassessmentapi.domain.{JsMarshaller, _}
 
 case class BlindPerson(country: Option[UkCountryCode] = None,
                        registrationAuthority: Option[String] = None,
                        spouseSurplusAllowance: Option[BigDecimal] = None,
                        wantSpouseToUseSurplusAllowance: Option[Boolean] = None)
 
-object BlindPerson extends BaseDomain[BlindPerson] {
+object BlindPerson extends JsMarshaller[BlindPerson] {
 
 
   override implicit val writes = Json.writes[BlindPerson]

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/charitablegiving/CharitableGiving.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/charitablegiving/CharitableGiving.scala
@@ -29,7 +29,7 @@ case class GiftAidPayments( totalInTaxYear: Option[BigDecimal] = None,
                             carriedBackToPreviousTaxYear: Option[BigDecimal] = None,
                             carriedFromNextTaxYear: Option[BigDecimal] = None)
 
-object GiftAidPayments extends JsMarshaller[GiftAidPayments] {
+object GiftAidPayments extends JsonMarshaller[GiftAidPayments] {
 
   override implicit val writes = Json.writes[GiftAidPayments]
 
@@ -74,7 +74,7 @@ object GiftAidPayments extends JsMarshaller[GiftAidPayments] {
 case class SharesAndSecurities( totalInTaxYear: BigDecimal,
                                 toNonUkCharities: Option[BigDecimal] = None)
 
-object SharesAndSecurities extends JsMarshaller[SharesAndSecurities] {
+object SharesAndSecurities extends JsonMarshaller[SharesAndSecurities] {
 
   override implicit val writes = Json.writes[SharesAndSecurities]
 
@@ -98,7 +98,7 @@ object SharesAndSecurities extends JsMarshaller[SharesAndSecurities] {
 case class LandAndProperties( totalInTaxYear: BigDecimal,
                               toNonUkCharities: Option[BigDecimal] = None)
 
-object LandAndProperties extends JsMarshaller[LandAndProperties] {
+object LandAndProperties extends JsonMarshaller[LandAndProperties] {
 
   override implicit val writes = Json.writes[LandAndProperties]
 
@@ -123,7 +123,7 @@ case class CharitableGiving( giftAidPayments: Option[GiftAidPayments] = None,
                              sharesSecurities: Option[SharesAndSecurities] = None,
                              landProperties: Option[LandAndProperties] = None)
 
-object CharitableGiving extends JsMarshaller[CharitableGiving] {
+object CharitableGiving extends JsonMarshaller[CharitableGiving] {
 
   override implicit val writes = Json.writes[CharitableGiving]
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/charitablegiving/CharitableGiving.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/charitablegiving/CharitableGiving.scala
@@ -29,7 +29,7 @@ case class GiftAidPayments( totalInTaxYear: Option[BigDecimal] = None,
                             carriedBackToPreviousTaxYear: Option[BigDecimal] = None,
                             carriedFromNextTaxYear: Option[BigDecimal] = None)
 
-object GiftAidPayments extends BaseDomain[GiftAidPayments] {
+object GiftAidPayments extends JsMarshaller[GiftAidPayments] {
 
   override implicit val writes = Json.writes[GiftAidPayments]
 
@@ -74,7 +74,7 @@ object GiftAidPayments extends BaseDomain[GiftAidPayments] {
 case class SharesAndSecurities( totalInTaxYear: BigDecimal,
                                 toNonUkCharities: Option[BigDecimal] = None)
 
-object SharesAndSecurities extends BaseDomain[SharesAndSecurities] {
+object SharesAndSecurities extends JsMarshaller[SharesAndSecurities] {
 
   override implicit val writes = Json.writes[SharesAndSecurities]
 
@@ -98,7 +98,7 @@ object SharesAndSecurities extends BaseDomain[SharesAndSecurities] {
 case class LandAndProperties( totalInTaxYear: BigDecimal,
                               toNonUkCharities: Option[BigDecimal] = None)
 
-object LandAndProperties extends BaseDomain[LandAndProperties] {
+object LandAndProperties extends JsMarshaller[LandAndProperties] {
 
   override implicit val writes = Json.writes[LandAndProperties]
 
@@ -123,7 +123,7 @@ case class CharitableGiving( giftAidPayments: Option[GiftAidPayments] = None,
                              sharesSecurities: Option[SharesAndSecurities] = None,
                              landProperties: Option[LandAndProperties] = None)
 
-object CharitableGiving extends BaseDomain[CharitableGiving] {
+object CharitableGiving extends JsMarshaller[CharitableGiving] {
 
   override implicit val writes = Json.writes[CharitableGiving]
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/childbenefit/ChildBenefit.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/childbenefit/ChildBenefit.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.selfassessmentapi.domain._
 case class ChildBenefit(amount: BigDecimal, numberOfChildren: Int, dateBenefitStopped: Option[LocalDate] = None)
 
 
-object ChildBenefit extends JsMarshaller[ChildBenefit] {
+object ChildBenefit extends JsonMarshaller[ChildBenefit] {
   override implicit val writes = Json.writes[ChildBenefit]
   override implicit val reads = (
     (__ \ "amount").read[BigDecimal](positiveAmountValidator("amount")) and

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/childbenefit/ChildBenefit.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/childbenefit/ChildBenefit.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.selfassessmentapi.domain._
 case class ChildBenefit(amount: BigDecimal, numberOfChildren: Int, dateBenefitStopped: Option[LocalDate] = None)
 
 
-object ChildBenefit extends BaseDomain[ChildBenefit] {
+object ChildBenefit extends JsMarshaller[ChildBenefit] {
   override implicit val writes = Json.writes[ChildBenefit]
   override implicit val reads = (
     (__ \ "amount").read[BigDecimal](positiveAmountValidator("amount")) and

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/employment/Benefit.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/employment/Benefit.scala
@@ -32,7 +32,7 @@ object BenefitType extends Enumeration {
 case class Benefit(id: Option[SummaryId] = None,
                    `type`: BenefitType, amount: BigDecimal)
 
-object Benefit extends BaseDomain[Benefit] {
+object Benefit extends JsMarshaller[Benefit] {
 
   implicit val seExpenseTypes = EnumJson.enumFormat(BenefitType, Some("Employment Benefit type is invalid"))
   implicit val writes = Json.writes[Benefit]

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/employment/Benefit.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/employment/Benefit.scala
@@ -32,7 +32,7 @@ object BenefitType extends Enumeration {
 case class Benefit(id: Option[SummaryId] = None,
                    `type`: BenefitType, amount: BigDecimal)
 
-object Benefit extends JsMarshaller[Benefit] {
+object Benefit extends JsonMarshaller[Benefit] {
 
   implicit val seExpenseTypes = EnumJson.enumFormat(BenefitType, Some("Employment Benefit type is invalid"))
   implicit val writes = Json.writes[Benefit]

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/employment/Employment.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/employment/Employment.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.selfassessmentapi.domain._
 
 case class Employment(id: Option[SourceId] = None)
 
-object Employment extends JsMarshaller[Employment]{
+object Employment extends JsonMarshaller[Employment]{
 
   implicit val writes = Json.writes[Employment]
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/employment/Employment.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/employment/Employment.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.selfassessmentapi.domain._
 
 case class Employment(id: Option[SourceId] = None)
 
-object Employment extends BaseDomain[Employment]{
+object Employment extends JsMarshaller[Employment]{
 
   implicit val writes = Json.writes[Employment]
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/employment/Expense.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/employment/Expense.scala
@@ -31,7 +31,7 @@ object ExpenseType extends Enumeration {
 case class Expense(id: Option[SummaryId] = None,
                    `type`: ExpenseType, amount: BigDecimal)
 
-object Expense extends BaseDomain[Expense]{
+object Expense extends JsMarshaller[Expense]{
 
   implicit val types = EnumJson.enumFormat(ExpenseType, Some("Employments expense type is invalid"))
   implicit val writes = Json.writes[Expense]

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/employment/Expense.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/employment/Expense.scala
@@ -31,7 +31,7 @@ object ExpenseType extends Enumeration {
 case class Expense(id: Option[SummaryId] = None,
                    `type`: ExpenseType, amount: BigDecimal)
 
-object Expense extends JsMarshaller[Expense]{
+object Expense extends JsonMarshaller[Expense]{
 
   implicit val types = EnumJson.enumFormat(ExpenseType, Some("Employments expense type is invalid"))
   implicit val writes = Json.writes[Expense]

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/employment/Income.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/employment/Income.scala
@@ -31,7 +31,7 @@ object IncomeType extends Enumeration {
 case class Income(id: Option[SummaryId] = None,
                   `type`: IncomeType, amount: BigDecimal)
 
-object Income extends JsMarshaller[Income] {
+object Income extends JsonMarshaller[Income] {
 
   implicit val types = EnumJson.enumFormat(IncomeType, Some("Employments income type is invalid"))
   implicit val writes = Json.writes[Income]

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/employment/Income.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/employment/Income.scala
@@ -31,7 +31,7 @@ object IncomeType extends Enumeration {
 case class Income(id: Option[SummaryId] = None,
                   `type`: IncomeType, amount: BigDecimal)
 
-object Income extends BaseDomain[Income] {
+object Income extends JsMarshaller[Income] {
 
   implicit val types = EnumJson.enumFormat(IncomeType, Some("Employments income type is invalid"))
   implicit val writes = Json.writes[Income]

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/employment/UKTaxPaid.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/employment/UKTaxPaid.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.selfassessmentapi.domain._
 
 case class UKTaxPaid(id: Option[SummaryId] = None, amount: BigDecimal)
 
-object UKTaxPaid extends JsMarshaller[UKTaxPaid]{
+object UKTaxPaid extends JsonMarshaller[UKTaxPaid]{
 
   implicit val writes = Json.writes[UKTaxPaid]
   implicit val reads: Reads[UKTaxPaid] = (

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/employment/UKTaxPaid.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/employment/UKTaxPaid.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.selfassessmentapi.domain._
 
 case class UKTaxPaid(id: Option[SummaryId] = None, amount: BigDecimal)
 
-object UKTaxPaid extends BaseDomain[UKTaxPaid]{
+object UKTaxPaid extends JsMarshaller[UKTaxPaid]{
 
   implicit val writes = Json.writes[UKTaxPaid]
   implicit val reads: Reads[UKTaxPaid] = (

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/furnishedholidaylettings/BalancingCharge.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/furnishedholidaylettings/BalancingCharge.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.selfassessmentapi.domain._
 
 case class BalancingCharge(id: Option[SummaryId]=None, amount: BigDecimal)
 
-object BalancingCharge extends BaseDomain[BalancingCharge] {
+object BalancingCharge extends JsMarshaller[BalancingCharge] {
 
   implicit val writes = Json.writes[BalancingCharge]
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/furnishedholidaylettings/BalancingCharge.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/furnishedholidaylettings/BalancingCharge.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.selfassessmentapi.domain._
 
 case class BalancingCharge(id: Option[SummaryId]=None, amount: BigDecimal)
 
-object BalancingCharge extends JsMarshaller[BalancingCharge] {
+object BalancingCharge extends JsonMarshaller[BalancingCharge] {
 
   implicit val writes = Json.writes[BalancingCharge]
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/furnishedholidaylettings/Expense.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/furnishedholidaylettings/Expense.scala
@@ -31,7 +31,7 @@ object ExpenseType extends Enumeration {
 case class Expense(id: Option[SummaryId] = None,
                    `type`: ExpenseType, amount: BigDecimal)
 
-object Expense extends BaseDomain[Expense] {
+object Expense extends JsMarshaller[Expense] {
 
   implicit val types = EnumJson.enumFormat(ExpenseType, Some("Furnished Holiday Lettings Expense type is invalid"))
   implicit val writes = Json.writes[Expense]

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/furnishedholidaylettings/Expense.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/furnishedholidaylettings/Expense.scala
@@ -31,7 +31,7 @@ object ExpenseType extends Enumeration {
 case class Expense(id: Option[SummaryId] = None,
                    `type`: ExpenseType, amount: BigDecimal)
 
-object Expense extends JsMarshaller[Expense] {
+object Expense extends JsonMarshaller[Expense] {
 
   implicit val types = EnumJson.enumFormat(ExpenseType, Some("Furnished Holiday Lettings Expense type is invalid"))
   implicit val writes = Json.writes[Expense]

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/furnishedholidaylettings/FurnishedHolidayLetting.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/furnishedholidaylettings/FurnishedHolidayLetting.scala
@@ -34,7 +34,7 @@ case class FurnishedHolidayLetting(id: Option[SourceId] = None,
                                    adjustments: Option[Adjustments] = None)
 
 
-object FurnishedHolidayLetting extends JsMarshaller[FurnishedHolidayLetting]{
+object FurnishedHolidayLetting extends JsonMarshaller[FurnishedHolidayLetting]{
 
   implicit val propertyLocationTypes = EnumJson.enumFormat(PropertyLocationType, Some("Furnished holiday lettings property location type is invalid"))
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/furnishedholidaylettings/FurnishedHolidayLetting.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/furnishedholidaylettings/FurnishedHolidayLetting.scala
@@ -34,7 +34,7 @@ case class FurnishedHolidayLetting(id: Option[SourceId] = None,
                                    adjustments: Option[Adjustments] = None)
 
 
-object FurnishedHolidayLetting extends BaseDomain[FurnishedHolidayLetting]{
+object FurnishedHolidayLetting extends JsMarshaller[FurnishedHolidayLetting]{
 
   implicit val propertyLocationTypes = EnumJson.enumFormat(PropertyLocationType, Some("Furnished holiday lettings property location type is invalid"))
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/furnishedholidaylettings/Income.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/furnishedholidaylettings/Income.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.selfassessmentapi.domain._
 case class Income(id: Option[SummaryId] = None,
                   amount: BigDecimal)
 
-object Income extends BaseDomain[Income] {
+object Income extends JsMarshaller[Income] {
 
   implicit val writes = Json.writes[Income]
   implicit val reads: Reads[Income] = (

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/furnishedholidaylettings/Income.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/furnishedholidaylettings/Income.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.selfassessmentapi.domain._
 case class Income(id: Option[SummaryId] = None,
                   amount: BigDecimal)
 
-object Income extends JsMarshaller[Income] {
+object Income extends JsonMarshaller[Income] {
 
   implicit val writes = Json.writes[Income]
   implicit val reads: Reads[Income] = (

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/furnishedholidaylettings/PrivateUseAdjustment.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/furnishedholidaylettings/PrivateUseAdjustment.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.selfassessmentapi.domain._
 
 case class PrivateUseAdjustment(id: Option[SummaryId]=None, amount: BigDecimal)
 
-object PrivateUseAdjustment extends JsMarshaller[PrivateUseAdjustment] {
+object PrivateUseAdjustment extends JsonMarshaller[PrivateUseAdjustment] {
 
   implicit val writes = Json.writes[PrivateUseAdjustment]
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/furnishedholidaylettings/PrivateUseAdjustment.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/furnishedholidaylettings/PrivateUseAdjustment.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.selfassessmentapi.domain._
 
 case class PrivateUseAdjustment(id: Option[SummaryId]=None, amount: BigDecimal)
 
-object PrivateUseAdjustment extends BaseDomain[PrivateUseAdjustment] {
+object PrivateUseAdjustment extends JsMarshaller[PrivateUseAdjustment] {
 
   implicit val writes = Json.writes[PrivateUseAdjustment]
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/pensioncontribution/PensionContribution.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/pensioncontribution/PensionContribution.scala
@@ -18,14 +18,14 @@ package uk.gov.hmrc.selfassessmentapi.domain.pensioncontribution
 
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
-import uk.gov.hmrc.selfassessmentapi.domain.{BaseDomain, _}
+import uk.gov.hmrc.selfassessmentapi.domain.{JsMarshaller, _}
 
 case class PensionContribution(ukRegisteredPension: Option[BigDecimal] = None,
                                retirementAnnuity: Option[BigDecimal] = None,
                                employerScheme: Option[BigDecimal] = None,
                                overseasPension: Option[BigDecimal] = None)
 
-object PensionContribution extends BaseDomain[PensionContribution] {
+object PensionContribution extends JsMarshaller[PensionContribution] {
 
   override implicit val writes = Json.writes[PensionContribution]
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/pensioncontribution/PensionContribution.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/pensioncontribution/PensionContribution.scala
@@ -18,14 +18,14 @@ package uk.gov.hmrc.selfassessmentapi.domain.pensioncontribution
 
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
-import uk.gov.hmrc.selfassessmentapi.domain.{JsMarshaller, _}
+import uk.gov.hmrc.selfassessmentapi.domain.{JsonMarshaller, _}
 
 case class PensionContribution(ukRegisteredPension: Option[BigDecimal] = None,
                                retirementAnnuity: Option[BigDecimal] = None,
                                employerScheme: Option[BigDecimal] = None,
                                overseasPension: Option[BigDecimal] = None)
 
-object PensionContribution extends JsMarshaller[PensionContribution] {
+object PensionContribution extends JsonMarshaller[PensionContribution] {
 
   override implicit val writes = Json.writes[PensionContribution]
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/selfemployment/BalancingCharge.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/selfemployment/BalancingCharge.scala
@@ -30,7 +30,7 @@ object BalancingChargeType extends Enumeration {
 
 case class BalancingCharge(id: Option[String] = None, `type`: BalancingChargeType, amount: BigDecimal)
 
-object BalancingCharge extends BaseDomain[BalancingCharge] {
+object BalancingCharge extends JsMarshaller[BalancingCharge] {
   implicit val writes = Json.writes[BalancingCharge]
   implicit val reads: Reads[BalancingCharge] = (
     Reads.pure(None) and

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/selfemployment/BalancingCharge.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/selfemployment/BalancingCharge.scala
@@ -30,7 +30,7 @@ object BalancingChargeType extends Enumeration {
 
 case class BalancingCharge(id: Option[String] = None, `type`: BalancingChargeType, amount: BigDecimal)
 
-object BalancingCharge extends JsMarshaller[BalancingCharge] {
+object BalancingCharge extends JsonMarshaller[BalancingCharge] {
   implicit val writes = Json.writes[BalancingCharge]
   implicit val reads: Reads[BalancingCharge] = (
     Reads.pure(None) and

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/selfemployment/Expense.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/selfemployment/Expense.scala
@@ -32,7 +32,7 @@ object ExpenseType extends Enumeration {
 
 case class Expense(id: Option[SummaryId] = None, `type`: ExpenseType, amount: BigDecimal)
 
-object Expense extends JsMarshaller[Expense] {
+object Expense extends JsonMarshaller[Expense] {
 
   implicit val writes = Json.writes[Expense]
   implicit val reads: Reads[Expense] = (

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/selfemployment/Expense.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/selfemployment/Expense.scala
@@ -32,7 +32,7 @@ object ExpenseType extends Enumeration {
 
 case class Expense(id: Option[SummaryId] = None, `type`: ExpenseType, amount: BigDecimal)
 
-object Expense extends BaseDomain[Expense] {
+object Expense extends JsMarshaller[Expense] {
 
   implicit val writes = Json.writes[Expense]
   implicit val reads: Reads[Expense] = (

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/selfemployment/GoodsAndServicesOwnUse.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/selfemployment/GoodsAndServicesOwnUse.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.selfassessmentapi.domain._
 
 case class GoodsAndServicesOwnUse(id: Option[String] = None, amount: BigDecimal)
 
-object GoodsAndServicesOwnUse extends JsMarshaller[GoodsAndServicesOwnUse]{
+object GoodsAndServicesOwnUse extends JsonMarshaller[GoodsAndServicesOwnUse]{
   implicit val writes = Json.writes[GoodsAndServicesOwnUse]
 
   implicit val reads = (

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/selfemployment/GoodsAndServicesOwnUse.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/selfemployment/GoodsAndServicesOwnUse.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.selfassessmentapi.domain._
 
 case class GoodsAndServicesOwnUse(id: Option[String] = None, amount: BigDecimal)
 
-object GoodsAndServicesOwnUse extends BaseDomain[GoodsAndServicesOwnUse]{
+object GoodsAndServicesOwnUse extends JsMarshaller[GoodsAndServicesOwnUse]{
   implicit val writes = Json.writes[GoodsAndServicesOwnUse]
 
   implicit val reads = (

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/selfemployment/Income.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/selfemployment/Income.scala
@@ -34,7 +34,7 @@ case class Income(id: Option[SummaryId] = None,
                   `type`: IncomeType,
                   amount: BigDecimal)
 
-object Income extends JsMarshaller[Income] {
+object Income extends JsonMarshaller[Income] {
 
   implicit val writes = Json.writes[Income]
   implicit val reads: Reads[Income] = (

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/selfemployment/Income.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/selfemployment/Income.scala
@@ -34,7 +34,7 @@ case class Income(id: Option[SummaryId] = None,
                   `type`: IncomeType,
                   amount: BigDecimal)
 
-object Income extends BaseDomain[Income] {
+object Income extends JsMarshaller[Income] {
 
   implicit val writes = Json.writes[Income]
   implicit val reads: Reads[Income] = (

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/selfemployment/SelfEmployment.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/selfemployment/SelfEmployment.scala
@@ -29,7 +29,7 @@ case class SelfEmployment(id: Option[SourceId] = None,
                           allowances: Option[Allowances] = None,
                           adjustments: Option[Adjustments] = None)
 
-object SelfEmployment extends BaseDomain[SelfEmployment]{
+object SelfEmployment extends JsMarshaller[SelfEmployment]{
 
   implicit val writes = Json.writes[SelfEmployment]
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/selfemployment/SelfEmployment.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/selfemployment/SelfEmployment.scala
@@ -29,7 +29,7 @@ case class SelfEmployment(id: Option[SourceId] = None,
                           allowances: Option[Allowances] = None,
                           adjustments: Option[Adjustments] = None)
 
-object SelfEmployment extends JsMarshaller[SelfEmployment]{
+object SelfEmployment extends JsonMarshaller[SelfEmployment]{
 
   implicit val writes = Json.writes[SelfEmployment]
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/studentsloan/StudentLoan.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/studentsloan/StudentLoan.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.Json._
 import play.api.libs.json._
 import uk.gov.hmrc.selfassessmentapi.domain._
 import uk.gov.hmrc.selfassessmentapi.controllers.definition.EnumJson
-import uk.gov.hmrc.selfassessmentapi.domain.{BaseDomain, PositiveMonetaryFieldDescription, TaxYearPropertyType}
+import uk.gov.hmrc.selfassessmentapi.domain.{JsMarshaller, PositiveMonetaryFieldDescription, TaxYearPropertyType}
 import uk.gov.hmrc.selfassessmentapi.domain.studentsloan.StudentLoanPlanType.StudentLoanPlanType
 
 object StudentLoanPlanType extends Enumeration {
@@ -31,7 +31,7 @@ object StudentLoanPlanType extends Enumeration {
 
 case class StudentLoan(planType: StudentLoanPlanType, deductedByEmployers: Option[BigDecimal])
 
-object StudentLoan extends BaseDomain[StudentLoan] {
+object StudentLoan extends JsMarshaller[StudentLoan] {
 
   implicit val format = EnumJson.enumFormat(StudentLoanPlanType, Some("Student Loan Plan type is invalid"))
   override implicit val writes = Json.writes[StudentLoan]

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/studentsloan/StudentLoan.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/studentsloan/StudentLoan.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.Json._
 import play.api.libs.json._
 import uk.gov.hmrc.selfassessmentapi.domain._
 import uk.gov.hmrc.selfassessmentapi.controllers.definition.EnumJson
-import uk.gov.hmrc.selfassessmentapi.domain.{JsMarshaller, PositiveMonetaryFieldDescription, TaxYearPropertyType}
+import uk.gov.hmrc.selfassessmentapi.domain.{JsonMarshaller, PositiveMonetaryFieldDescription, TaxYearPropertyType}
 import uk.gov.hmrc.selfassessmentapi.domain.studentsloan.StudentLoanPlanType.StudentLoanPlanType
 
 object StudentLoanPlanType extends Enumeration {
@@ -31,7 +31,7 @@ object StudentLoanPlanType extends Enumeration {
 
 case class StudentLoan(planType: StudentLoanPlanType, deductedByEmployers: Option[BigDecimal])
 
-object StudentLoan extends JsMarshaller[StudentLoan] {
+object StudentLoan extends JsonMarshaller[StudentLoan] {
 
   implicit val format = EnumJson.enumFormat(StudentLoanPlanType, Some("Student Loan Plan type is invalid"))
   override implicit val writes = Json.writes[StudentLoan]

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/taxrefundedorsetoff/TaxRefundedOrSetOff.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/taxrefundedorsetoff/TaxRefundedOrSetOff.scala
@@ -17,11 +17,11 @@
 package uk.gov.hmrc.selfassessmentapi.domain.taxrefundedorsetoff
 
 import play.api.libs.json._
-import uk.gov.hmrc.selfassessmentapi.domain.{BaseDomain, _}
+import uk.gov.hmrc.selfassessmentapi.domain.{JsMarshaller, _}
 
 case class TaxRefundedOrSetOff(amount: BigDecimal)
 
-object TaxRefundedOrSetOff extends BaseDomain[TaxRefundedOrSetOff] {
+object TaxRefundedOrSetOff extends JsMarshaller[TaxRefundedOrSetOff] {
   implicit val writes = Json.writes[TaxRefundedOrSetOff]
 
   implicit val reads: Reads[TaxRefundedOrSetOff] = (__ \ "amount").read[BigDecimal](positiveAmountValidator("amount")).map {

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/taxrefundedorsetoff/TaxRefundedOrSetOff.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/taxrefundedorsetoff/TaxRefundedOrSetOff.scala
@@ -17,11 +17,11 @@
 package uk.gov.hmrc.selfassessmentapi.domain.taxrefundedorsetoff
 
 import play.api.libs.json._
-import uk.gov.hmrc.selfassessmentapi.domain.{JsMarshaller, _}
+import uk.gov.hmrc.selfassessmentapi.domain.{JsonMarshaller, _}
 
 case class TaxRefundedOrSetOff(amount: BigDecimal)
 
-object TaxRefundedOrSetOff extends JsMarshaller[TaxRefundedOrSetOff] {
+object TaxRefundedOrSetOff extends JsonMarshaller[TaxRefundedOrSetOff] {
   implicit val writes = Json.writes[TaxRefundedOrSetOff]
 
   implicit val reads: Reads[TaxRefundedOrSetOff] = (__ \ "amount").read[BigDecimal](positiveAmountValidator("amount")).map {

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/BalancingCharge.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/BalancingCharge.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.selfassessmentapi.domain._
 case class BalancingCharge(id: Option[SummaryId] = None,
                            amount: BigDecimal)
 
-object BalancingCharge extends JsMarshaller[BalancingCharge]{
+object BalancingCharge extends JsonMarshaller[BalancingCharge]{
 
   implicit val writes = Json.writes[BalancingCharge]
   implicit val reads: Reads[BalancingCharge] = (

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/BalancingCharge.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/BalancingCharge.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.selfassessmentapi.domain._
 case class BalancingCharge(id: Option[SummaryId] = None,
                            amount: BigDecimal)
 
-object BalancingCharge extends BaseDomain[BalancingCharge]{
+object BalancingCharge extends JsMarshaller[BalancingCharge]{
 
   implicit val writes = Json.writes[BalancingCharge]
   implicit val reads: Reads[BalancingCharge] = (

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/Expense.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/Expense.scala
@@ -33,7 +33,7 @@ case class Expense(id: Option[SummaryId] = None,
                    `type`: ExpenseType,
                    amount: BigDecimal)
 
-object Expense extends JsMarshaller[Expense] {
+object Expense extends JsonMarshaller[Expense] {
 
   implicit val types = EnumJson.enumFormat(ExpenseType, Some("UK Property Expense type is invalid"))
   implicit val writes = Json.writes[Expense]

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/Expense.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/Expense.scala
@@ -33,7 +33,7 @@ case class Expense(id: Option[SummaryId] = None,
                    `type`: ExpenseType,
                    amount: BigDecimal)
 
-object Expense extends BaseDomain[Expense] {
+object Expense extends JsMarshaller[Expense] {
 
   implicit val types = EnumJson.enumFormat(ExpenseType, Some("UK Property Expense type is invalid"))
   implicit val writes = Json.writes[Expense]

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/Income.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/Income.scala
@@ -33,7 +33,7 @@ case class Income(id: Option[SummaryId] = None,
                   `type`: IncomeType,
                   amount: BigDecimal)
 
-object Income extends BaseDomain[Income] {
+object Income extends JsMarshaller[Income] {
 
   implicit val types = EnumJson.enumFormat(IncomeType, Some("UK Property Income type is invalid"))
   override implicit val writes = Json.writes[Income]

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/Income.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/Income.scala
@@ -33,7 +33,7 @@ case class Income(id: Option[SummaryId] = None,
                   `type`: IncomeType,
                   amount: BigDecimal)
 
-object Income extends JsMarshaller[Income] {
+object Income extends JsonMarshaller[Income] {
 
   implicit val types = EnumJson.enumFormat(IncomeType, Some("UK Property Income type is invalid"))
   override implicit val writes = Json.writes[Income]

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/PrivateUseAdjustment.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/PrivateUseAdjustment.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.selfassessmentapi.domain._
 case class PrivateUseAdjustment(id: Option[SummaryId] = None,
                            amount: BigDecimal)
 
-object PrivateUseAdjustment extends BaseDomain[PrivateUseAdjustment] {
+object PrivateUseAdjustment extends JsMarshaller[PrivateUseAdjustment] {
 
   implicit val writes = Json.writes[PrivateUseAdjustment]
   implicit val reads: Reads[PrivateUseAdjustment] = (

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/PrivateUseAdjustment.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/PrivateUseAdjustment.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.selfassessmentapi.domain._
 case class PrivateUseAdjustment(id: Option[SummaryId] = None,
                            amount: BigDecimal)
 
-object PrivateUseAdjustment extends JsMarshaller[PrivateUseAdjustment] {
+object PrivateUseAdjustment extends JsonMarshaller[PrivateUseAdjustment] {
 
   implicit val writes = Json.writes[PrivateUseAdjustment]
   implicit val reads: Reads[PrivateUseAdjustment] = (

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/TaxPaid.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/TaxPaid.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.selfassessmentapi.domain._
 case class TaxPaid(id: Option[SummaryId] = None,
                    amount: BigDecimal)
 
-object TaxPaid extends JsMarshaller[TaxPaid] {
+object TaxPaid extends JsonMarshaller[TaxPaid] {
 
   implicit val writes = Json.writes[TaxPaid]
   implicit val reads: Reads[TaxPaid] = (

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/TaxPaid.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/TaxPaid.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.selfassessmentapi.domain._
 case class TaxPaid(id: Option[SummaryId] = None,
                    amount: BigDecimal)
 
-object TaxPaid extends BaseDomain[TaxPaid] {
+object TaxPaid extends JsMarshaller[TaxPaid] {
 
   implicit val writes = Json.writes[TaxPaid]
   implicit val reads: Reads[TaxPaid] = (

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/UKProperty.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/UKProperty.scala
@@ -29,7 +29,7 @@ case class UKProperty(id: Option[SourceId] = None,
                       rentARoomRelief: Option[BigDecimal] = None)
 
 
-object UKProperty extends BaseDomain[UKProperty] {
+object UKProperty extends JsMarshaller[UKProperty] {
 
   implicit val propertyLocationTypes = EnumJson.enumFormat(PropertyLocationType, Some("Furnished holiday lettings property location type is invalid"))
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/UKProperty.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/ukproperty/UKProperty.scala
@@ -29,7 +29,7 @@ case class UKProperty(id: Option[SourceId] = None,
                       rentARoomRelief: Option[BigDecimal] = None)
 
 
-object UKProperty extends JsMarshaller[UKProperty] {
+object UKProperty extends JsonMarshaller[UKProperty] {
 
   implicit val propertyLocationTypes = EnumJson.enumFormat(PropertyLocationType, Some("Furnished holiday lettings property location type is invalid"))
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/unearnedincome/Benefits.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/unearnedincome/Benefits.scala
@@ -31,7 +31,7 @@ object BenefitType extends Enumeration {
 
 case class Benefit(id: Option[String] = None, `type`: BenefitType, amount: BigDecimal, taxDeduction: BigDecimal)
 
-object Benefit extends JsMarshaller[Benefit] {
+object Benefit extends JsonMarshaller[Benefit] {
 
   implicit val savingsIncomeTypes = EnumJson.enumFormat(BenefitType, Some("Unearned Income Benefit type is invalid"))
   implicit val writes = Json.writes[Benefit]

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/unearnedincome/Benefits.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/unearnedincome/Benefits.scala
@@ -31,7 +31,7 @@ object BenefitType extends Enumeration {
 
 case class Benefit(id: Option[String] = None, `type`: BenefitType, amount: BigDecimal, taxDeduction: BigDecimal)
 
-object Benefit extends BaseDomain[Benefit] {
+object Benefit extends JsMarshaller[Benefit] {
 
   implicit val savingsIncomeTypes = EnumJson.enumFormat(BenefitType, Some("Unearned Income Benefit type is invalid"))
   implicit val writes = Json.writes[Benefit]

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/unearnedincome/Dividend.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/unearnedincome/Dividend.scala
@@ -30,7 +30,7 @@ object DividendType extends Enumeration {
 
 case class Dividend(id: Option[String] = None, `type`: DividendType, amount: BigDecimal)
 
-object Dividend extends JsMarshaller[Dividend] {
+object Dividend extends JsonMarshaller[Dividend] {
 
   implicit val writes = Json.writes[Dividend]
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/unearnedincome/Dividend.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/unearnedincome/Dividend.scala
@@ -30,7 +30,7 @@ object DividendType extends Enumeration {
 
 case class Dividend(id: Option[String] = None, `type`: DividendType, amount: BigDecimal)
 
-object Dividend extends BaseDomain[Dividend] {
+object Dividend extends JsMarshaller[Dividend] {
 
   implicit val writes = Json.writes[Dividend]
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/unearnedincome/SavingsIncome.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/unearnedincome/SavingsIncome.scala
@@ -30,7 +30,7 @@ object SavingsIncomeType extends Enumeration {
 
 case class SavingsIncome(id: Option[String] = None, `type`: SavingsIncomeType, amount: BigDecimal)
 
-object SavingsIncome extends BaseDomain[SavingsIncome] {
+object SavingsIncome extends JsMarshaller[SavingsIncome] {
 
   implicit val writes = Json.writes[SavingsIncome]
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/unearnedincome/SavingsIncome.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/unearnedincome/SavingsIncome.scala
@@ -30,7 +30,7 @@ object SavingsIncomeType extends Enumeration {
 
 case class SavingsIncome(id: Option[String] = None, `type`: SavingsIncomeType, amount: BigDecimal)
 
-object SavingsIncome extends JsMarshaller[SavingsIncome] {
+object SavingsIncome extends JsonMarshaller[SavingsIncome] {
 
   implicit val writes = Json.writes[SavingsIncome]
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/unearnedincome/UnearnedIncome.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/unearnedincome/UnearnedIncome.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.selfassessmentapi.domain._
 
 case class UnearnedIncome(id: Option[SourceId] = None)
 
-object UnearnedIncome extends BaseDomain[UnearnedIncome] {
+object UnearnedIncome extends JsMarshaller[UnearnedIncome] {
 
   implicit val writes = Json.writes[UnearnedIncome]
 

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/unearnedincome/UnearnedIncome.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/unearnedincome/UnearnedIncome.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.selfassessmentapi.domain._
 
 case class UnearnedIncome(id: Option[SourceId] = None)
 
-object UnearnedIncome extends JsMarshaller[UnearnedIncome] {
+object UnearnedIncome extends JsonMarshaller[UnearnedIncome] {
 
   implicit val writes = Json.writes[UnearnedIncome]
 

--- a/test/uk/gov/hmrc/selfassessmentapi/repositories/live/SelfEmploymentRepositorySpec.scala
+++ b/test/uk/gov/hmrc/selfassessmentapi/repositories/live/SelfEmploymentRepositorySpec.scala
@@ -22,7 +22,7 @@ import org.scalatest.BeforeAndAfterEach
 import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.domain.SaUtr
 import uk.gov.hmrc.selfassessmentapi.MongoEmbeddedDatabase
-import uk.gov.hmrc.selfassessmentapi.domain.JsMarshaller
+import uk.gov.hmrc.selfassessmentapi.domain.JsonMarshaller
 import uk.gov.hmrc.selfassessmentapi.domain.selfemployment._
 import uk.gov.hmrc.selfassessmentapi.repositories.domain.{MongoSelfEmployment, MongoSelfEmploymentIncomeSummary}
 import uk.gov.hmrc.selfassessmentapi.repositories.{SourceRepository, SummaryRepository}
@@ -33,7 +33,7 @@ class SelfEmploymentRepositorySpec extends MongoEmbeddedDatabase with BeforeAndA
 
   private val mongoRepository = new SelfEmploymentMongoRepository
   private val selfEmploymentRepository: SourceRepository[SelfEmployment] = mongoRepository
-  private val summariesMap: Map[JsMarshaller[_], SummaryRepository[_]] = Map(Income -> mongoRepository.IncomeRepository,
+  private val summariesMap: Map[JsonMarshaller[_], SummaryRepository[_]] = Map(Income -> mongoRepository.IncomeRepository,
     Expense -> mongoRepository.ExpenseRepository, BalancingCharge -> mongoRepository.BalancingChargeRepository,
     GoodsAndServicesOwnUse -> mongoRepository.GoodsAndServicesOwnUseRepository)
 

--- a/test/uk/gov/hmrc/selfassessmentapi/repositories/live/SelfEmploymentRepositorySpec.scala
+++ b/test/uk/gov/hmrc/selfassessmentapi/repositories/live/SelfEmploymentRepositorySpec.scala
@@ -22,7 +22,7 @@ import org.scalatest.BeforeAndAfterEach
 import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.domain.SaUtr
 import uk.gov.hmrc.selfassessmentapi.MongoEmbeddedDatabase
-import uk.gov.hmrc.selfassessmentapi.domain.BaseDomain
+import uk.gov.hmrc.selfassessmentapi.domain.JsMarshaller
 import uk.gov.hmrc.selfassessmentapi.domain.selfemployment._
 import uk.gov.hmrc.selfassessmentapi.repositories.domain.{MongoSelfEmployment, MongoSelfEmploymentIncomeSummary}
 import uk.gov.hmrc.selfassessmentapi.repositories.{SourceRepository, SummaryRepository}
@@ -33,7 +33,7 @@ class SelfEmploymentRepositorySpec extends MongoEmbeddedDatabase with BeforeAndA
 
   private val mongoRepository = new SelfEmploymentMongoRepository
   private val selfEmploymentRepository: SourceRepository[SelfEmployment] = mongoRepository
-  private val summariesMap: Map[BaseDomain[_], SummaryRepository[_]] = Map(Income -> mongoRepository.IncomeRepository,
+  private val summariesMap: Map[JsMarshaller[_], SummaryRepository[_]] = Map(Income -> mongoRepository.IncomeRepository,
     Expense -> mongoRepository.ExpenseRepository, BalancingCharge -> mongoRepository.BalancingChargeRepository,
     GoodsAndServicesOwnUse -> mongoRepository.GoodsAndServicesOwnUseRepository)
 

--- a/test/uk/gov/hmrc/selfassessmentapi/repositories/live/UnearnedIncomeRepositorySpec.scala
+++ b/test/uk/gov/hmrc/selfassessmentapi/repositories/live/UnearnedIncomeRepositorySpec.scala
@@ -23,7 +23,7 @@ import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.domain.SaUtr
 import uk.gov.hmrc.selfassessmentapi.MongoEmbeddedDatabase
 import uk.gov.hmrc.selfassessmentapi.domain.unearnedincome.{Dividend, SavingsIncome, UnearnedIncome}
-import uk.gov.hmrc.selfassessmentapi.domain.{JsMarshaller, TaxYear}
+import uk.gov.hmrc.selfassessmentapi.domain.{JsonMarshaller, TaxYear}
 import uk.gov.hmrc.selfassessmentapi.repositories.{SourceRepository, SummaryRepository}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -32,7 +32,7 @@ class UnearnedIncomeRepositorySpec extends MongoEmbeddedDatabase with BeforeAndA
 
   private val mongoRepository = new UnearnedIncomeMongoRepository
   private val unearnedIncomeMongoRepository: SourceRepository[UnearnedIncome] = mongoRepository
-  private val summariesMap: Map[JsMarshaller[_], SummaryRepository[_]] = Map(Dividend -> mongoRepository.DividendRepository, SavingsIncome -> mongoRepository.SavingsIncomeRepository)
+  private val summariesMap: Map[JsonMarshaller[_], SummaryRepository[_]] = Map(Dividend -> mongoRepository.DividendRepository, SavingsIncome -> mongoRepository.SavingsIncomeRepository)
 
 
   override def beforeEach() {

--- a/test/uk/gov/hmrc/selfassessmentapi/repositories/live/UnearnedIncomeRepositorySpec.scala
+++ b/test/uk/gov/hmrc/selfassessmentapi/repositories/live/UnearnedIncomeRepositorySpec.scala
@@ -23,7 +23,7 @@ import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.domain.SaUtr
 import uk.gov.hmrc.selfassessmentapi.MongoEmbeddedDatabase
 import uk.gov.hmrc.selfassessmentapi.domain.unearnedincome.{Dividend, SavingsIncome, UnearnedIncome}
-import uk.gov.hmrc.selfassessmentapi.domain.{BaseDomain, TaxYear}
+import uk.gov.hmrc.selfassessmentapi.domain.{JsMarshaller, TaxYear}
 import uk.gov.hmrc.selfassessmentapi.repositories.{SourceRepository, SummaryRepository}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -32,7 +32,7 @@ class UnearnedIncomeRepositorySpec extends MongoEmbeddedDatabase with BeforeAndA
 
   private val mongoRepository = new UnearnedIncomeMongoRepository
   private val unearnedIncomeMongoRepository: SourceRepository[UnearnedIncome] = mongoRepository
-  private val summariesMap: Map[BaseDomain[_], SummaryRepository[_]] = Map(Dividend -> mongoRepository.DividendRepository, SavingsIncome -> mongoRepository.SavingsIncomeRepository)
+  private val summariesMap: Map[JsMarshaller[_], SummaryRepository[_]] = Map(Dividend -> mongoRepository.DividendRepository, SavingsIncome -> mongoRepository.SavingsIncomeRepository)
 
 
   override def beforeEach() {


### PR DESCRIPTION
A tech debt refactoring to rename this trait to something that better describes it's function.

As with all refactoring, this will probably result in some merge conflicts.