### PR TITLE
Mtdsa 483 error handling v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,10 @@ Install [Service Manager](https://github.com/hmrc/service-manager), if you want 
 
 Start the app:
 
-    run -Drun.mode=Dev
+    sbt run -Drun.mode=Dev
 
 Now you can test sandbox:
 
-    UTR=2234567890 ;# or UTR=1234567895
     curl -v http://localhost:9000/sandbox/$UTR -H 'Accept: application/vnd.hmrc.1.0+json'
 
 ### License

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/ErrorResponses.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/ErrorResponses.scala
@@ -16,7 +16,26 @@
 
 package uk.gov.hmrc.selfassessmentapi.controllers
 
+import play.api.libs.json.Json
 import uk.gov.hmrc.api.controllers.ErrorResponse
+import uk.gov.hmrc.selfassessmentapi.domain.ErrorCode.ErrorCode
+
 
 case object ErrorSaUtrInvalid extends ErrorResponse(400, "SA_UTR_INVALID", "The provided SA UTR is invalid")
+
 case object ErrorNotImplemented extends ErrorResponse(501, "NOT_IMPLEMENTED", "The resource is not implemented")
+
+case class ErrorBadRequest(code: ErrorCode, override val message: String)
+  extends ErrorResponse(400, code.toString, message)
+
+case class InvalidPart(code: ErrorCode, message: String, path : String)
+
+object InvalidPart {
+  implicit val writes = Json.writes[InvalidPart]
+}
+
+case class InvalidRequest(code: ErrorCode, message: String, errors: Seq[InvalidPart])
+
+object InvalidRequest {
+  implicit val writes = Json.writes[InvalidRequest]
+}

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/ErrorResult.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/ErrorResult.scala
@@ -16,6 +16,10 @@
 
 package uk.gov.hmrc.selfassessmentapi.controllers
 
-import uk.gov.hmrc.selfassessmentapi.domain._
+import uk.gov.hmrc.selfassessmentapi.domain.ValidationErrors
 
-case class ErrorResult(message: Option[String] = None, validationErrors: Option[ValidationErrors] = None)
+trait ErrorResult
+
+case class GenericErrorResult(message: String) extends ErrorResult
+
+case class ValidationErrorResult(validationErrors: ValidationErrors) extends ErrorResult

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/SourceController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/SourceController.scala
@@ -37,8 +37,8 @@ trait SourceController extends BaseController with Links with SourceTypeSupport 
       case Left(errorResult) =>
         Future.successful {
           errorResult match {
-            case ErrorResult(Some(message), _) => BadRequest(message)
-            case ErrorResult(_, Some(errors)) => BadRequest(failedValidationJson(errors))
+            case GenericErrorResult(message) => BadRequest(message)
+            case ValidationErrorResult(errors) => BadRequest(failedValidationJson(errors))
             case _ => BadRequest
           }
         }
@@ -58,8 +58,8 @@ trait SourceController extends BaseController with Links with SourceTypeSupport 
       case Left(errorResult) =>
         Future.successful {
           errorResult match {
-            case ErrorResult(Some(message), _) => BadRequest(message)
-            case ErrorResult(_, Some(errors)) => BadRequest(failedValidationJson(errors))
+            case GenericErrorResult(message) => BadRequest(message)
+            case ValidationErrorResult(errors) => BadRequest(failedValidationJson(errors))
             case _ => BadRequest
           }
         }

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/SourceController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/SourceController.scala
@@ -17,8 +17,8 @@
 package uk.gov.hmrc.selfassessmentapi.controllers
 
 import play.api.hal.HalLink
-import play.api.libs.json.JsValue
 import play.api.libs.json.Json._
+import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.Request
 import play.api.mvc.hal._
 import uk.gov.hmrc.domain.SaUtr
@@ -37,8 +37,10 @@ trait SourceController extends BaseController with Links with SourceTypeSupport 
       case Left(errorResult) =>
         Future.successful {
           errorResult match {
+            // TODO untested
             case GenericErrorResult(message) => BadRequest(message)
-            case ValidationErrorResult(errors) => BadRequest(failedValidationJson(errors))
+            case ValidationErrorResult(errors) => BadRequest(Json.toJson(invalidRequest(errors)))
+            // TODO untested
             case _ => BadRequest
           }
         }
@@ -49,7 +51,7 @@ trait SourceController extends BaseController with Links with SourceTypeSupport 
   protected def readSource(saUtr: SaUtr, taxYear: TaxYear, sourceType: SourceType, sourceId: SourceId) = {
     sourceHandler(sourceType).findById(saUtr, taxYear, sourceId) map {
       case Some(summary) => Ok(halResource(summary, sourceLinks(saUtr, taxYear, sourceType, sourceId)))
-      case None => NotFound
+      case None => notFound
     }
   }
 
@@ -58,14 +60,16 @@ trait SourceController extends BaseController with Links with SourceTypeSupport 
       case Left(errorResult) =>
         Future.successful {
           errorResult match {
+            // TODO untested
             case GenericErrorResult(message) => BadRequest(message)
-            case ValidationErrorResult(errors) => BadRequest(failedValidationJson(errors))
+            case ValidationErrorResult(errors) => BadRequest(Json.toJson(invalidRequest(errors)))
+            // TODO untested
             case _ => BadRequest
           }
         }
       case Right(result) => result.map {
         case true => Ok(halResource(obj(), sourceLinks(saUtr, taxYear, sourceType, sourceId)))
-        case false => NotFound
+        case false => notFound
       }
     }
   }
@@ -73,7 +77,8 @@ trait SourceController extends BaseController with Links with SourceTypeSupport 
   protected def deleteSource(saUtr: SaUtr, taxYear: TaxYear, sourceType: SourceType, sourceId: SourceId) = {
     sourceHandler(sourceType).delete(saUtr, taxYear, sourceId) map {
       case true => NoContent
-      case false => NotFound
+      // TODO untested??
+      case false => notFound
     }
   }
 

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/SummaryController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/SummaryController.scala
@@ -19,10 +19,9 @@ package uk.gov.hmrc.selfassessmentapi.controllers
 import play.api.hal.HalLink
 import play.api.libs.json.JsValue
 import play.api.libs.json.Json._
-import play.api.mvc.{Request, Result}
+import play.api.mvc.Request
 import play.api.mvc.hal._
 import uk.gov.hmrc.domain.SaUtr
-import uk.gov.hmrc.selfassessmentapi.FeatureSwitchAction
 import uk.gov.hmrc.selfassessmentapi.config.AppContext
 import uk.gov.hmrc.selfassessmentapi.domain._
 
@@ -44,8 +43,8 @@ trait SummaryController extends BaseController with Links with SourceTypeSupport
       case Left(errorResult) =>
         Future.successful {
           errorResult match {
-            case ErrorResult(Some(message), _) => BadRequest(message)
-            case ErrorResult(_, Some(errors)) => BadRequest(failedValidationJson(errors))
+            case GenericErrorResult(message) => BadRequest(message)
+            case ValidationErrorResult(errors) => BadRequest(failedValidationJson(errors))
             case _ => BadRequest
           }
         }
@@ -69,8 +68,8 @@ trait SummaryController extends BaseController with Links with SourceTypeSupport
       case Left(errorResult) =>
         Future.successful {
           errorResult match {
-            case ErrorResult(Some(message), _) => BadRequest(message)
-            case ErrorResult(_, Some(errors)) => BadRequest(failedValidationJson(errors))
+            case GenericErrorResult(message) => BadRequest(message)
+            case ValidationErrorResult(errors) => BadRequest(failedValidationJson(errors))
             case _ => BadRequest
           }
         }

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/SummaryController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/SummaryController.scala
@@ -17,8 +17,8 @@
 package uk.gov.hmrc.selfassessmentapi.controllers
 
 import play.api.hal.HalLink
-import play.api.libs.json.JsValue
 import play.api.libs.json.Json._
+import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.Request
 import play.api.mvc.hal._
 import uk.gov.hmrc.domain.SaUtr
@@ -43,13 +43,16 @@ trait SummaryController extends BaseController with Links with SourceTypeSupport
       case Left(errorResult) =>
         Future.successful {
           errorResult match {
+            // TODO untested
             case GenericErrorResult(message) => BadRequest(message)
-            case ValidationErrorResult(errors) => BadRequest(failedValidationJson(errors))
+            case ValidationErrorResult(errors) => BadRequest(Json.toJson(invalidRequest(errors)))
+            // TODO untested
             case _ => BadRequest
           }
         }
       case Right(futOptId) => futOptId.map {
         case Some(id) => Created(halResource(obj(), Set(HalLink("self", sourceTypeAndSummaryTypeIdHref(saUtr, taxYear, sourceType, sourceId, summaryTypeName, id)))))
+        // TODO untested
         case _ => BadRequest
       }
     }
@@ -59,7 +62,7 @@ trait SummaryController extends BaseController with Links with SourceTypeSupport
     handler(sourceType, summaryTypeName).findById(saUtr, taxYear, sourceId, summaryId) map {
       case Some(summary) =>
         Ok(halResource(summary, Set(HalLink("self", sourceTypeAndSummaryTypeIdHref(saUtr, taxYear, sourceType, sourceId, summaryTypeName, summaryId)))))
-      case None => NotFound
+      case None => notFound
     }
   }
 
@@ -68,14 +71,17 @@ trait SummaryController extends BaseController with Links with SourceTypeSupport
       case Left(errorResult) =>
         Future.successful {
           errorResult match {
+            // TODO untested
             case GenericErrorResult(message) => BadRequest(message)
-            case ValidationErrorResult(errors) => BadRequest(failedValidationJson(errors))
+            case ValidationErrorResult(errors) => BadRequest(Json.toJson(invalidRequest(errors)))
+            // TODO untested
             case _ => BadRequest
           }
         }
       case Right(optResult) => optResult.map {
         case true => Ok(halResource(obj(), Set(HalLink("self", sourceTypeAndSummaryTypeIdHref(saUtr, taxYear, sourceType, sourceId, summaryTypeName, summaryId)))))
-        case false => NotFound
+        // TODO untested???
+        case false => notFound
       }
     }
 
@@ -85,7 +91,8 @@ trait SummaryController extends BaseController with Links with SourceTypeSupport
   protected def deleteSummary(saUtr: SaUtr, taxYear: TaxYear, sourceType: SourceType, sourceId: SourceId, summaryTypeName: String, summaryId: SummaryId) = {
     handler(sourceType, summaryTypeName).delete(saUtr, taxYear, sourceId, summaryId) map {
       case true => NoContent
-      case false => NotFound
+      // TODO untested???
+      case false => notFound
     }
   }
 

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/live/LiabilityController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/live/LiabilityController.scala
@@ -52,7 +52,8 @@ object LiabilityController extends uk.gov.hmrc.selfassessmentapi.controllers.Lia
         )
         Ok(halResource(Json.toJson(liability), links))
 
-      case _ => NotFound
+      // TODO untested???
+      case _ => notFound
     }
   }
 

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/package.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/package.scala
@@ -26,20 +26,16 @@ package object controllers {
   def validate[T](id: String, jsValue: JsValue)(implicit reads: Reads[T]): Either[ErrorResult, String] = {
     Try(jsValue.validate[T]) match {
       case Success(JsSuccess(payload, _)) => Right(id)
-      case Success(JsError(errors)) =>
-        Left(ErrorResult(validationErrors = Some(errors)))
-      case Failure(e) =>
-        Left(ErrorResult(message = Some(s"could not parse body due to ${e.getMessage}")))
+      case Success(JsError(errors)) => Left(ValidationErrorResult(errors))
+      case Failure(e) => Left(GenericErrorResult(s"could not parse body due to ${e.getMessage}"))
     }
   }
 
   def validate[T, R](jsValue: JsValue)(f: T => Future[R])(implicit reads: Reads[T]): Either[ErrorResult, Future[R]] = {
     Try(jsValue.validate[T]) match {
       case Success(JsSuccess(payload, _)) => Right(f(payload))
-      case Success(JsError(errors)) =>
-        Left(ErrorResult(validationErrors = Some(errors)))
-      case Failure(e) =>
-        Left(ErrorResult(message = Some(s"could not parse body due to ${e.getMessage}")))
+      case Success(JsError(errors)) => Left(ValidationErrorResult(errors))
+      case Failure(e) => Left(GenericErrorResult(s"could not parse body due to ${e.getMessage}"))
     }
   }
 }

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/sandbox/TaxYearDiscoveryController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/sandbox/TaxYearDiscoveryController.scala
@@ -19,16 +19,16 @@ package uk.gov.hmrc.selfassessmentapi.controllers.sandbox
 import java.lang.Integer._
 
 import org.joda.time.LocalDate
-import play.api.libs.json.JsArray
+import play.api.libs.json.Json
 import play.api.libs.json.Json._
 import play.api.mvc.Action
 import play.api.mvc.hal._
 import uk.gov.hmrc.domain.SaUtr
 import uk.gov.hmrc.selfassessmentapi.config.AppContext
-import uk.gov.hmrc.selfassessmentapi.controllers.{BaseController, Links}
+import uk.gov.hmrc.selfassessmentapi.controllers.{BaseController, InvalidPart, InvalidRequest, Links}
 import uk.gov.hmrc.selfassessmentapi.domain.ErrorCode._
 import uk.gov.hmrc.selfassessmentapi.domain.TaxYearProperties._
-import uk.gov.hmrc.selfassessmentapi.domain.{TaxYear, TaxYearProperties}
+import uk.gov.hmrc.selfassessmentapi.domain.{ErrorCode, TaxYear, TaxYearProperties}
 import uk.gov.hmrc.selfassessmentapi.views.Helpers._
 
 import scala.concurrent.Future
@@ -43,8 +43,7 @@ object TaxYearDiscoveryController extends BaseController with Links {
   private def taxYearValidationErrors(path: String, yearFromBody : LocalDate, yearFromUrl: String) = {
     val endOfTaxYear = new LocalDate(parseInt(yearFromUrl.split("-")(0)) + 1, 4, 5)
     if (yearFromBody.isAfter(endOfTaxYear)) {
-      Some(addValidationError(path, Some(BENEFIT_STOPPED_DATE_INVALID),
-        s"The dateBenefitStopped must be before the end of the tax year: $yearFromUrl"))
+      Some(InvalidPart(BENEFIT_STOPPED_DATE_INVALID, s"The dateBenefitStopped must be before the end of the tax year: $yearFromUrl", path))
     } else None
   }
 
@@ -54,14 +53,14 @@ object TaxYearDiscoveryController extends BaseController with Links {
         dateBenefitStopped <- childBenefit.dateBenefitStopped
         taxYearValidationResult <- taxYearValidationErrors("/taxYearProperties/childBenefit/dateBenefitStopped",
                                                            dateBenefitStopped, taxYear)
-    } yield Seq(taxYearValidationResult)
+    } yield taxYearValidationResult
   }
 
   final def update(utr: SaUtr, taxYear: TaxYear) = Action.async(parse.json) { implicit request =>
     withJsonBody[TaxYearProperties] {
       taxYearProperties =>
         validateRequest(taxYearProperties, taxYear.taxYear) match {
-          case Some(errors) => Future.successful(BadRequest(JsArray(errors)))
+          case Some(invalidPart) => Future.successful(BadRequest(Json.toJson(InvalidRequest(ErrorCode.INVALID_REQUEST, "Invalid request", Seq(invalidPart)))))
           case None => Future.successful(Ok(halResource(obj(), discoveryLinks(utr, taxYear))))
         }
     }

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/ErrorCode.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/ErrorCode.scala
@@ -20,7 +20,11 @@ import uk.gov.hmrc.selfassessmentapi.controllers.definition.EnumJson
 
 object ErrorCode extends Enumeration {
   type ErrorCode = Value
-  val MAX_FIELD_LENGTH_EXCEEDED,
+  val
+    // TODO check name is OK
+  INVALID_REQUEST,
+  TAX_YEAR_INVALID,
+  MAX_FIELD_LENGTH_EXCEEDED,
   INVALID_MONETARY_AMOUNT,
   INVALID_TAX_DEDUCTION_AMOUNT,
   COMMENCEMENT_DATE_NOT_IN_THE_PAST,

--- a/func/uk/gov/hmrc/selfassessmentapi/AcceptHeaderSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/AcceptHeaderSpec.scala
@@ -22,7 +22,7 @@ class AcceptHeaderSpec extends BaseFunctionalSpec {
         .get(s"/sandbox/$saUtr/$taxYear/self-employments/$selfEmploymentId").withoutAcceptHeader()
         .thenAssertThat()
         .statusIs(406)
-        .body(_ \ "code").is("ACCEPT_HEADER_INVALID")
+        .bodyIsError("ACCEPT_HEADER_INVALID")
     }
   }
 

--- a/func/uk/gov/hmrc/selfassessmentapi/AuthorisationSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/AuthorisationSpec.scala
@@ -14,7 +14,9 @@ class AuthorisationSpec extends BaseFunctionalSpec {
         .when()
         .get(s"/$saUtr/$taxYear/self-employments/$selfEmploymentId")
         .thenAssertThat()
+        // TODO - 401 Not Authenticated, should be 403 Forbidden
         .statusIs(401)
+        // TODO - check the body (and add whatever code is need to create that body)
     }
   }
 }

--- a/func/uk/gov/hmrc/selfassessmentapi/FeatureSwitchSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/FeatureSwitchSpec.scala
@@ -46,14 +46,14 @@ class FeatureSwitchSpec extends BaseFunctionalSpec {
         .when()
         .get(s"/$saUtr/$taxYear/${SelfEmployments.name}/$sourceId/expenses")
         .thenAssertThat()
-        .resourceIsNotImplemented()
+        .isNotImplemented
 
       given()
         .userIsAuthorisedForTheResource(saUtr)
         .when()
         .get(s"/$saUtr/$taxYear/${SelfEmployments.name}/$sourceId/balancing-charges")
         .thenAssertThat()
-        .resourceIsNotImplemented()
+        .isNotImplemented
     }
   }
 
@@ -64,7 +64,7 @@ class FeatureSwitchSpec extends BaseFunctionalSpec {
         .when()
         .get(s"/$saUtr/$taxYear/${Employments.name}")
         .thenAssertThat()
-        .resourceIsNotImplemented()
+        .isNotImplemented
     }
   }
 

--- a/func/uk/gov/hmrc/selfassessmentapi/TaxYearValidationSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/TaxYearValidationSpec.scala
@@ -4,6 +4,7 @@ import play.api.libs.json.Json
 import play.api.test.FakeApplication
 import uk.gov.hmrc.selfassessmentapi.domain.ErrorCode._
 import uk.gov.hmrc.support.BaseFunctionalSpec
+import uk.gov.hmrc.support.BaseFunctionalSpec
 
 // FIXME: Refactor into live and sandbox tests
 
@@ -84,8 +85,7 @@ class TaxYearValidationSpec extends BaseFunctionalSpec {
       when()
         .put(s"/sandbox/$saUtr/$taxYear", Some(payload))
         .thenAssertThat()
-        .statusIs(400)
-        .bodyContainsError(("/taxYearProperties/childBenefit/dateBenefitStopped", "BENEFIT_STOPPED_DATE_INVALID"))
+        .isValidationError("/taxYearProperties/childBenefit/dateBenefitStopped", "BENEFIT_STOPPED_DATE_INVALID")
     }
   }
 
@@ -94,8 +94,7 @@ class TaxYearValidationSpec extends BaseFunctionalSpec {
       when()
         .get(s"/sandbox/$saUtr/not-a-tax-year").withAcceptHeader()
         .thenAssertThat()
-        .statusIs(400)
-        .body(_ \ "message").is("ERROR_TAX_YEAR_INVALID")
+        .isBadRequest("TAX_YEAR_INVALID")
     }
   }
 
@@ -120,8 +119,7 @@ class TaxYearValidationSpec extends BaseFunctionalSpec {
         .when()
         .get(s"/$saUtr/not-a-tax-year").withAcceptHeader()
         .thenAssertThat()
-        .statusIs(400)
-        .body(_ \ "message").is("ERROR_TAX_YEAR_INVALID")
+        .isBadRequest("TAX_YEAR_INVALID")
     }
   }
 
@@ -149,9 +147,7 @@ class TaxYearValidationSpec extends BaseFunctionalSpec {
         .when()
         .put(s"/$saUtr/$taxYear", Some(payload))
         .thenAssertThat()
-        .statusIs(400)
-        .bodyHasPath("""(0) \ code """, ONLY_PENSION_CONTRIBUTIONS_SUPPORTED)
-        .bodyHasPath("""(0) \ path """, "/taxYearProperties")
+        .isValidationError("/taxYearProperties", "ONLY_PENSION_CONTRIBUTIONS_SUPPORTED")
     }
   }
 
@@ -211,7 +207,7 @@ class TaxYearFeatureSwitchOnSpec extends BaseFunctionalSpec {
         .when()
         .put(s"/$saUtr/$taxYear", Some(payload))
         .thenAssertThat()
-        .resourceIsNotImplemented()
+        .isNotImplemented
     }
   }
 }

--- a/func/uk/gov/hmrc/selfassessmentapi/live/CustomerResolverControllerSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/live/CustomerResolverControllerSpec.scala
@@ -22,7 +22,9 @@ class CustomerResolverControllerSpec extends BaseFunctionalSpec {
       .when()
         .get("/")
       .thenAssertThat()
+        // TODO this error is incorrect against W3C spec, it should be 403
         .statusIs(401)
+        // TODO check body for correct format
     }
   }
 

--- a/func/uk/gov/hmrc/selfassessmentapi/live/LiabilityControllerSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/live/LiabilityControllerSpec.scala
@@ -202,7 +202,7 @@ class LiabilityControllerSpec extends BaseFunctionalSpec {
         .when()
         .delete(s"/$saUtr/$taxYear/liabilities/1234")
         .thenAssertThat()
-        .resourceIsNotImplemented()
+        .isNotImplemented
     }
   }
 
@@ -212,7 +212,7 @@ class LiabilityControllerSpec extends BaseFunctionalSpec {
         .when()
         .get(s"/$saUtr/$taxYear/liabilities")
         .thenAssertThat()
-        .resourceIsNotImplemented()
+        .isNotImplemented
     }
   }
 

--- a/func/uk/gov/hmrc/selfassessmentapi/live/NotImplementedSourcesSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/live/NotImplementedSourcesSpec.scala
@@ -1,7 +1,6 @@
 package uk.gov.hmrc.selfassessmentapi.live
 
 import reactivemongo.bson.BSONObjectID
-import uk.gov.hmrc.selfassessmentapi.controllers.live.SourceController
 import uk.gov.hmrc.selfassessmentapi.domain.SourceTypes
 import uk.gov.hmrc.support.BaseFunctionalSpec
 
@@ -19,7 +18,7 @@ class NotImplementedSourcesSpec extends BaseFunctionalSpec {
           .when()
           .post(s"/$saUtr/$taxYear/${source.name}", Some(source.example()))
           .thenAssertThat()
-          .resourceIsNotImplemented()
+          .isNotImplemented
       }
     }
   }
@@ -32,7 +31,7 @@ class NotImplementedSourcesSpec extends BaseFunctionalSpec {
           .when()
           .get(s"/$saUtr/$taxYear/${source.name}/$sourceId")
           .thenAssertThat()
-          .resourceIsNotImplemented()
+          .isNotImplemented
       }
     }
   }
@@ -45,7 +44,7 @@ class NotImplementedSourcesSpec extends BaseFunctionalSpec {
           .when()
           .get(s"/$saUtr/$taxYear/${source.name}")
           .thenAssertThat()
-          .resourceIsNotImplemented()
+          .isNotImplemented
       }
     }
   }
@@ -58,7 +57,7 @@ class NotImplementedSourcesSpec extends BaseFunctionalSpec {
           .when()
           .put(s"/$saUtr/$taxYear/${source.name}/$sourceId", Some(source.example()))
           .thenAssertThat()
-          .resourceIsNotImplemented()
+          .isNotImplemented
       }
     }
   }
@@ -71,7 +70,7 @@ class NotImplementedSourcesSpec extends BaseFunctionalSpec {
           .when()
           .delete(s"/$saUtr/$taxYear/${source.name}/$sourceId")
           .thenAssertThat()
-          .resourceIsNotImplemented()
+          .isNotImplemented
       }
     }
   }

--- a/func/uk/gov/hmrc/selfassessmentapi/live/NotImplementedSummariesSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/live/NotImplementedSummariesSpec.scala
@@ -2,10 +2,6 @@ package uk.gov.hmrc.selfassessmentapi.live
 
 import java.util.UUID
 
-import uk.gov.hmrc.selfassessmentapi.controllers.live.SummaryController
-import uk.gov.hmrc.selfassessmentapi.domain.selfemployment.SourceType.SelfEmployments
-import uk.gov.hmrc.selfassessmentapi.domain.selfemployment.SummaryTypes
-import uk.gov.hmrc.selfassessmentapi.domain.selfemployment.SummaryTypes.GoodsAndServicesOwnUses
 import uk.gov.hmrc.selfassessmentapi.domain.{SummaryType, _}
 import uk.gov.hmrc.support.BaseFunctionalSpec
 
@@ -32,7 +28,7 @@ class NotImplementedSummariesSpec extends BaseFunctionalSpec {
            .post(Some(summary.example()))
            .to(s"/$saUtr/$taxYear/${source.name}/$sourceId/${summary.name}")
            .thenAssertThat()
-           .resourceIsNotImplemented()
+           .isNotImplemented
        }
      }
     }
@@ -47,7 +43,7 @@ class NotImplementedSummariesSpec extends BaseFunctionalSpec {
             .when()
             .get(s"/$saUtr/$taxYear/${source.name}/$sourceId/${summary.name}/$summaryId")
             .thenAssertThat()
-            .resourceIsNotImplemented()
+            .isNotImplemented
         }
       }
     }
@@ -62,7 +58,7 @@ class NotImplementedSummariesSpec extends BaseFunctionalSpec {
             .when()
             .delete(s"/$saUtr/$taxYear/${source.name}/$sourceId/${summary.name}/$summaryId")
             .thenAssertThat()
-            .resourceIsNotImplemented()
+            .isNotImplemented
         }
       }
     }
@@ -78,7 +74,7 @@ class NotImplementedSummariesSpec extends BaseFunctionalSpec {
             .put(Some(summary.example()))
             .at(s"/$saUtr/$taxYear/${source.name}/$sourceId/${summary.name}/$summaryId")
             .thenAssertThat()
-            .resourceIsNotImplemented()
+            .isNotImplemented
         }
       }
     }
@@ -93,7 +89,7 @@ class NotImplementedSummariesSpec extends BaseFunctionalSpec {
             .when()
             .get(s"/$saUtr/$taxYear/${source.name}/$sourceId/${summary.name}")
             .thenAssertThat()
-            .resourceIsNotImplemented()
+            .isNotImplemented
         }
       }
     }

--- a/func/uk/gov/hmrc/selfassessmentapi/live/SummaryControllerSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/live/SummaryControllerSpec.scala
@@ -83,8 +83,9 @@ class SummaryControllerSpec extends BaseFunctionalSpec {
             .statusIs(204)
           .when()
             .get(s"/$saUtr/$taxYear/${sourceType.name}/%sourceId%/${summaryType.name}/%summaryId%")
+            .withAcceptHeader()
             .thenAssertThat()
-            .statusIs(404)
+            .isNotFound
         }
       }
     }
@@ -107,9 +108,9 @@ class SummaryControllerSpec extends BaseFunctionalSpec {
           .when()
             .post(s"/$saUtr/$taxYear/${sourceType.name}/%sourceId%/${summaryType.name}",
               invalidRequestBody(summaryType))
+            .withAcceptHeader()
             .thenAssertThat()
-            .statusIs(400)
-            .bodyContainsError(invalidErrorResponse(summaryType))
+            .isValidationError(invalidErrorResponse(summaryType))
         }
       }
     }
@@ -138,9 +139,9 @@ class SummaryControllerSpec extends BaseFunctionalSpec {
           .when()
             .put(s"/$saUtr/$taxYear/${sourceType.name}/%sourceId%/${summaryType.name}/%summaryId%",
               invalidRequestBody(summaryType))
+            .withAcceptHeader()
             .thenAssertThat()
-            .statusIs(400)
-            .bodyContainsError(invalidErrorResponse(summaryType))
+            .isValidationError(invalidErrorResponse(summaryType))
         }
       }
     }
@@ -160,8 +161,9 @@ class SummaryControllerSpec extends BaseFunctionalSpec {
             .bodyHasLink("self", s"/self-assessment/$saUtr/$taxYear/${sourceType.name}/.+".r)
           .when()
             .get(s"/$saUtr/$taxYear/${sourceType.name}/%sourceId%/${summaryType.name}/12334567")
+            .withAcceptHeader()
             .thenAssertThat()
-            .statusIs(404)
+            .isNotFound
         }
       }
     }
@@ -181,8 +183,9 @@ class SummaryControllerSpec extends BaseFunctionalSpec {
             .bodyHasLink("self", s"/self-assessment/$saUtr/$taxYear/${sourceType.name}/.+".r)
           .when()
             .delete(s"/$saUtr/$taxYear/${sourceType.name}/%sourceId%/${summaryType.name}/12334567")
+            .withAcceptHeader()
             .thenAssertThat()
-            .statusIs(404)
+            .isNotFound
         }
       }
     }

--- a/func/uk/gov/hmrc/selfassessmentapi/sandbox/SourceControllerSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/sandbox/SourceControllerSpec.scala
@@ -15,7 +15,7 @@ class SourceControllerSpec extends BaseFunctionalSpec {
       when()
         .get(s"/sandbox/$saUtr/$taxYear/blah")
         .thenAssertThat()
-        .statusIs(404)
+        .isNotFound
   }
 
     "return a 201 response with links to newly created source" in {

--- a/func/uk/gov/hmrc/selfassessmentapi/sandbox/SummaryControllerSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/sandbox/SummaryControllerSpec.scala
@@ -32,7 +32,7 @@ class SummaryControllerSpec extends BaseFunctionalSpec {
       when()
         .post(s"/sandbox/$saUtr/$taxYear/self-employments/$sourceId/incomes", Some(toJson(Income(None, Turnover, BigDecimal(-1000.12)))))
         .thenAssertThat()
-        .statusIs(400)
+        .isValidationError("/amount", "INVALID_MONETARY_AMOUNT")
     }
   }
 
@@ -41,7 +41,7 @@ class SummaryControllerSpec extends BaseFunctionalSpec {
       when()
         .post(s"/sandbox/$saUtr/$taxYear/self-employments/$sourceId/incoms", Some(toJson(Income(None, Turnover, BigDecimal(-1000.12)))))
         .thenAssertThat()
-        .statusIs(404)
+        .isNotFound
     }
   }
 

--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -87,7 +87,9 @@ private object AppDependencies {
         "org.scalatestplus" %% "play" % "1.2.0" % scope,
         "com.github.tomakehurst" % "wiremock" % "1.54" % scope,
         "de.flapdoodle.embed" % "de.flapdoodle.embed.mongo" % "1.50.3" % scope,
-        "org.mongodb" %% "casbah" % "3.1.0" % scope
+        "org.mongodb" %% "casbah" % "3.1.0" % scope,
+        // this line is only needed for coverage
+        "org.scoverage" %% "scalac-scoverage-runtime" % "1.1.1" % scope
       )
     }.test
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,5 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "0.8.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "0.10.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.10")
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")


### PR DESCRIPTION
There are some questions this created in my mind to think about:

- When a user accesses a UTR, it gets a `401 Not Authenticated`. They are, in fact, authenticated. They are not authorised, and therefore should get a `403 Forbidden` response. Should we change this?
- There are not tests for when auth either does not respond due to network issue, or returns `500 Server Error`. When it returns a 500, the API Consumer gets a 401. Is this correct?
- We override `onError` and `onBadRequest` in `MicroserviceGlobal`. The super-method audits the errors. The overridden versions do not. Should they?
- There are no tests for server errors. Should we have some?
- There are un-tested lines of code, for example, match statements with default branches that should never match. Return `BadRequest`, when it should probably be an AssertionError. What should be done (if anything)?