### PR TITLE
MTDSA-509 bug invalid date

### DIFF
--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/BaseController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/BaseController.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.selfassessmentapi.controllers
 
 import play.api.data.validation.ValidationError
-import play.api.i18n.Messages
 import play.api.libs.json._
 import play.api.mvc.{Request, Result}
 import uk.gov.hmrc.api.controllers.ErrorNotFound
@@ -58,7 +57,7 @@ trait BaseController
       (path, errSeq) <- errors
       error <- errSeq
     } yield {
-      InvalidPart(extractErrorCode(error), Messages(error.message), path.toString())
+      InvalidPart(extractErrorCode(error), error.message, path.toString())
     }
   }
 

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/BaseController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/BaseController.scala
@@ -16,6 +16,8 @@
 
 package uk.gov.hmrc.selfassessmentapi.controllers
 
+import play.api.data.validation.ValidationError
+import play.api.i18n.Messages
 import play.api.libs.json._
 import play.api.mvc.{Request, Result}
 import uk.gov.hmrc.api.controllers.ErrorNotFound
@@ -55,8 +57,15 @@ trait BaseController
     for {
       (path, errSeq) <- errors
       error <- errSeq
-      code <- error.args.headOption.filter(_.isInstanceOf[ErrorCode]).map(_.asInstanceOf[ErrorCode])
-    } yield
-      InvalidPart(code, error.message, path.toString())
+    } yield {
+      InvalidPart(extractErrorCode(error), Messages(error.message), path.toString())
+    }
+  }
+
+  private def extractErrorCode(error: ValidationError): ErrorCode = {
+    error.args.headOption
+      .filter(_.isInstanceOf[ErrorCode])
+      .map(_.asInstanceOf[ErrorCode])
+      .getOrElse(ErrorCode.INVALID_FIELD)
   }
 }

--- a/app/uk/gov/hmrc/selfassessmentapi/domain/ErrorCode.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/ErrorCode.scala
@@ -23,6 +23,7 @@ object ErrorCode extends Enumeration {
   val
     // TODO check name is OK
   INVALID_REQUEST,
+  INVALID_FIELD,
   TAX_YEAR_INVALID,
   MAX_FIELD_LENGTH_EXCEEDED,
   INVALID_MONETARY_AMOUNT,

--- a/test/uk/gov/hmrc/selfassessmentapi/controllers/BaseControllerSpec.scala
+++ b/test/uk/gov/hmrc/selfassessmentapi/controllers/BaseControllerSpec.scala
@@ -1,0 +1,24 @@
+package uk.gov.hmrc.selfassessmentapi.controllers
+
+import org.scalatest.{Matchers, WordSpecLike}
+import play.api.data.validation.ValidationError
+import play.api.libs.json.JsPath
+import uk.gov.hmrc.selfassessmentapi.domain.ErrorCode
+
+class BaseControllerSpec extends WordSpecLike with Matchers {
+
+  val controller = new BaseController {
+    override val context = ""
+  }
+
+  "invalid parts" should {
+    "transform validation errors into matching sequence of invalid parts" in {
+
+      val errors = Seq((JsPath \ "commencementDate", List(ValidationError("error.expected.jodadate.format", Seq()))))
+      val request = controller.invalidRequest(errors)
+
+      request.errors.head shouldBe InvalidPart(ErrorCode.INVALID_FIELD, "error.expected.jodadate.format", "/commencementDate")
+    }
+  }
+
+}


### PR DESCRIPTION
@rakeshavasarala , this address the actual bug (not returning an error when validation fails). I think we also have a bigger question about how to deal with the validations errors that get returned to `JsError` branch in`withJsonBody`. Basically, they don't get codes, so we must use a generic code. Theres is a mechanism for translating errors https://www.playframework.com/documentation/2.5.x/ScalaI18N. These errors are separate from the ones that validate for things like making sure `commencementDate` is in the past.