### PR TITLE
MTDSA-511 - address untested bits

### DIFF
--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/BaseController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/BaseController.scala
@@ -39,14 +39,9 @@ trait BaseController
 
   override protected def withJsonBody[T](f: (T) => Future[Result])(
     implicit request: Request[JsValue], m: Manifest[T], reads: Reads[T]) =
-    Try(request.body.validate[T]) match {
-      case Success(JsSuccess(payload, _)) => f(payload)
-      case Success(JsError(errors)) =>
-        // TODO untested
-        Future.successful(BadRequest(Json.toJson(invalidRequest(errors))))
-      case Failure(e) =>
-        // TODO untested
-        Future.successful(BadRequest(s"could not parse body due to ${e.getMessage}"))
+    request.body.validate[T] match {
+      case JsSuccess(payload, _) => f(payload)
+      case JsError(errors) => Future.successful(BadRequest(Json.toJson(invalidRequest(errors))))
     }
 
   def invalidRequest(errors: ValidationErrors) =

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/SourceController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/SourceController.scala
@@ -73,7 +73,6 @@ trait SourceController extends BaseController with Links with SourceTypeSupport 
   protected def deleteSource(saUtr: SaUtr, taxYear: TaxYear, sourceType: SourceType, sourceId: SourceId) = {
     sourceHandler(sourceType).delete(saUtr, taxYear, sourceId) map {
       case true => NoContent
-      // TODO untested??
       case false => notFound
     }
   }

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/SummaryController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/SummaryController.scala
@@ -76,7 +76,6 @@ trait SummaryController extends BaseController with Links with SourceTypeSupport
         }
       case Right(optResult) => optResult.map {
         case true => Ok(halResource(obj(), Set(HalLink("self", sourceTypeAndSummaryTypeIdHref(saUtr, taxYear, sourceType, sourceId, summaryTypeName, summaryId)))))
-        // TODO untested???
         case false => notFound
       }
     }
@@ -87,7 +86,6 @@ trait SummaryController extends BaseController with Links with SourceTypeSupport
   protected def deleteSummary(saUtr: SaUtr, taxYear: TaxYear, sourceType: SourceType, sourceId: SourceId, summaryTypeName: String, summaryId: SummaryId) = {
     handler(sourceType, summaryTypeName).delete(saUtr, taxYear, sourceId, summaryId) map {
       case true => NoContent
-      // TODO untested???
       case false => notFound
     }
   }

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/SummaryController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/SummaryController.scala
@@ -50,8 +50,7 @@ trait SummaryController extends BaseController with Links with SourceTypeSupport
         }
       case Right(futOptId) => futOptId.map {
         case Some(id) => Created(halResource(obj(), Set(HalLink("self", sourceTypeAndSummaryTypeIdHref(saUtr, taxYear, sourceType, sourceId, summaryTypeName, id)))))
-        // TODO untested
-        case _ => BadRequest
+        case _ => notFound
       }
     }
   }

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/live/LiabilityController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/live/LiabilityController.scala
@@ -49,8 +49,6 @@ object LiabilityController extends uk.gov.hmrc.selfassessmentapi.controllers.Lia
           HalLink("self", liabilityHref(utr, taxYear))
         )
         Ok(halResource(Json.toJson(liability), links))
-
-      // TODO untested???
       case _ => notFound
     }
   }

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/live/TaxYearDiscoveryController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/live/TaxYearDiscoveryController.scala
@@ -76,10 +76,8 @@ object TaxYearDiscoveryController extends BaseController with Links {
             validateRequest(taxYearProperties, taxYear.taxYear) match {
               case Some(invalidPart) => Future.successful(BadRequest(Json.toJson(InvalidRequest(ErrorCode.INVALID_REQUEST, "Invalid request", Seq(invalidPart)))))
               case None =>
-                repository.updateTaxYearProperties(utr, taxYear, taxYearProperties).map {
-                  case true => Ok(halResource(obj(), buildSourceHalLinks(utr, taxYear)))
-                  // TODO untested
-                  case false => notFound
+                repository.updateTaxYearProperties(utr, taxYear, taxYearProperties).map { x =>
+                  Ok(halResource(obj(), buildSourceHalLinks(utr, taxYear)))
                 }
             }
           }

--- a/func/uk/gov/hmrc/selfassessmentapi/live/LiabilityControllerSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/live/LiabilityControllerSpec.scala
@@ -25,6 +25,15 @@ class LiabilityControllerSpec extends BaseFunctionalSpec {
 
   "retrieve liability" should {
 
+    "return a not found response when a liability has not been requested" in {
+      given()
+        .userIsAuthorisedForTheResource(saUtr)
+        .when()
+        .get(s"/$saUtr/$taxYear/liability")
+        .thenAssertThat()
+        .isNotFound
+    }
+
     "return a 200 response with liability details" in {
 
       /*

--- a/func/uk/gov/hmrc/selfassessmentapi/live/SummaryControllerSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/live/SummaryControllerSpec.scala
@@ -116,6 +116,21 @@ class SummaryControllerSpec extends BaseFunctionalSpec {
     }
   }
 
+  "I" should {
+    "not be able to create summary for a non existent source" in {
+      val summaryTypes = uk.gov.hmrc.selfassessmentapi.domain.selfemployment.SummaryTypes
+
+      given()
+        .userIsAuthorisedForTheResource(saUtr)
+        .when()
+        .post(s"/$saUtr/$taxYear/${SourceTypes.SelfEmployments.name}/1234567890/${summaryTypes.Incomes.name}",
+          Some(summaryTypes.Incomes.example()))
+        .withAcceptHeader()
+        .thenAssertThat()
+        .isNotFound
+    }
+  }
+
 
 
   "I" should {

--- a/func/uk/gov/hmrc/selfassessmentapi/live/SummaryControllerSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/live/SummaryControllerSpec.scala
@@ -191,4 +191,26 @@ class SummaryControllerSpec extends BaseFunctionalSpec {
     }
   }
 
+  "I" should {
+    "not be able to update a non existent summary" in {
+      implementedSources foreach { sourceType =>
+        implementedSummaries(sourceType) foreach { summaryType =>
+          given()
+            .userIsAuthorisedForTheResource(saUtr)
+          .when()
+            .post(s"/$saUtr/$taxYear/${sourceType.name}", Some(sourceType.example()))
+            .thenAssertThat()
+            .statusIs(201)
+            .contentTypeIsHalJson()
+            .bodyHasLink("self", s"/self-assessment/$saUtr/$taxYear/${sourceType.name}/.+".r)
+          .when()
+            .put(s"/$saUtr/$taxYear/${sourceType.name}/%sourceId%/${summaryType.name}/12334567", Some(summaryType.example()))
+            .withAcceptHeader()
+            .thenAssertThat()
+            .isNotFound
+        }
+      }
+    }
+  }
+
 }

--- a/test/uk/gov/hmrc/selfassessmentapi/repositories/SelfAssessmentRepositorySpec.scala
+++ b/test/uk/gov/hmrc/selfassessmentapi/repositories/SelfAssessmentRepositorySpec.scala
@@ -140,8 +140,6 @@ class SelfAssessmentRepositorySpec extends MongoEmbeddedDatabase with BeforeAndA
       val taxYearProps2 = TaxYearProperties(pensionContributions = Some(PensionContribution(ukRegisteredPension = Some(50000.00))))
       val result = await(mongoRepository.updateTaxYearProperties(saUtr, taxYear, taxYearProps2))
 
-      result shouldBe true
-
       val records = await(mongoRepository.findTaxYearProperties(saUtr, taxYear))
       records.size shouldBe 1
       records shouldEqual Some(taxYearProps2)


### PR DESCRIPTION
- tests for not found scenarios
- refactored tax year properties update to use atomicUpsert which simplifies the response. It previously used 2 queries to do the update, the first was touch which uses atomicUpsert and then atomicUpdate, so it wasn't actually atomic.