### PR TITLE
[MTDSA-511] [DM] Updated the generic error response to have a json body

### DIFF
--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/BaseController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/BaseController.scala
@@ -47,6 +47,9 @@ trait BaseController
   def invalidRequest(errors: ValidationErrors) =
     InvalidRequest(ErrorCode.INVALID_REQUEST, "Validation failed", invalidPartsSeq(errors))
 
+  def invalidRequest(message: String) =
+    ErrorBadRequest(ErrorCode.INVALID_REQUEST, message)
+
   private def invalidPartsSeq(errors: ValidationErrors): Seq[InvalidPart] = {
     for {
       (path, errSeq) <- errors

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/SourceController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/SourceController.scala
@@ -37,8 +37,7 @@ trait SourceController extends BaseController with Links with SourceTypeSupport 
       case Left(errorResult) =>
         Future.successful {
           errorResult match {
-            // TODO untested
-            case GenericErrorResult(message) => BadRequest(message)
+            case GenericErrorResult(message) => BadRequest(Json.toJson(invalidRequest(message)))
             case ValidationErrorResult(errors) => BadRequest(Json.toJson(invalidRequest(errors)))
           }
         }
@@ -58,8 +57,7 @@ trait SourceController extends BaseController with Links with SourceTypeSupport 
       case Left(errorResult) =>
         Future.successful {
           errorResult match {
-            // TODO untested
-            case GenericErrorResult(message) => BadRequest(message)
+            case GenericErrorResult(message) => BadRequest(Json.toJson(invalidRequest(message)))
             case ValidationErrorResult(errors) => BadRequest(Json.toJson(invalidRequest(errors)))
           }
         }

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/SummaryController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/SummaryController.scala
@@ -43,8 +43,7 @@ trait SummaryController extends BaseController with Links with SourceTypeSupport
       case Left(errorResult) =>
         Future.successful {
           errorResult match {
-            // TODO untested
-            case GenericErrorResult(message) => BadRequest(message)
+            case GenericErrorResult(message) => BadRequest(Json.toJson(invalidRequest(message)))
             case ValidationErrorResult(errors) => BadRequest(Json.toJson(invalidRequest(errors)))
           }
         }
@@ -68,8 +67,7 @@ trait SummaryController extends BaseController with Links with SourceTypeSupport
       case Left(errorResult) =>
         Future.successful {
           errorResult match {
-            // TODO untested
-            case GenericErrorResult(message) => BadRequest(message)
+            case GenericErrorResult(message) => BadRequest(Json.toJson(invalidRequest(message)))
             case ValidationErrorResult(errors) => BadRequest(Json.toJson(invalidRequest(errors)))
           }
         }


### PR DESCRIPTION
Removed the "untested" comments. These lines aren't reachable in our functional tests. They will be executed when an exception occurs during the Json validation, but at the moment we have nothing easily reproducable that will cause this. 