### PR TITLE
[MTDSA-522] [DM] Configure api context to allow it to be empty

### DIFF
--- a/app/uk/gov/hmrc/selfassessmentapi/config/AppContext.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/config/AppContext.scala
@@ -24,7 +24,7 @@ object AppContext extends ServicesConfig {
   lazy val appUrl = current.configuration.getString("appUrl").getOrElse(throw new RuntimeException("appUrl is not configured"))
   lazy val apiGatewayContext = current.configuration.getString("api.gateway.context")
   lazy val apiGatewayRegistrationContext = apiGatewayContext.getOrElse(throw new RuntimeException("api.gateway.context is not configured"))
-  lazy val apiGatewayLinkContext = apiGatewayContext.map(ctx => s"/$ctx").getOrElse("")
+  lazy val apiGatewayLinkContext = apiGatewayContext.map(x => if(x.isEmpty) x else s"/$x").getOrElse("")
   lazy val apiStatus = current.configuration.getString("api.status").getOrElse(throw new RuntimeException("api.status is not configured"))
   lazy val serviceLocatorUrl: String = baseUrl("service-locator")
   lazy val authUrl: String = baseUrl("auth")

--- a/app/uk/gov/hmrc/selfassessmentapi/config/AppContext.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/config/AppContext.scala
@@ -22,7 +22,9 @@ import uk.gov.hmrc.play.config.ServicesConfig
 object AppContext extends ServicesConfig {
   lazy val appName = current.configuration.getString("appName").getOrElse(throw new RuntimeException("appName is not configured"))
   lazy val appUrl = current.configuration.getString("appUrl").getOrElse(throw new RuntimeException("appUrl is not configured"))
-  lazy val apiGatewayContext = current.configuration.getString("api.gateway.context").getOrElse(throw new RuntimeException("api.gateway.context is not configured"))
+  lazy val apiGatewayContext = current.configuration.getString("api.gateway.context")
+  lazy val apiGatewayRegistrationContext = apiGatewayContext.getOrElse(throw new RuntimeException("api.gateway.context is not configured"))
+  lazy val apiGatewayLinkContext = apiGatewayContext.map(ctx => s"/$ctx").getOrElse("")
   lazy val apiStatus = current.configuration.getString("api.status").getOrElse(throw new RuntimeException("api.status is not configured"))
   lazy val serviceLocatorUrl: String = baseUrl("service-locator")
   lazy val authUrl: String = baseUrl("auth")

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/Links.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/Links.scala
@@ -23,7 +23,7 @@ trait Links {
 
   val context: String
 
-  private def createLink(endpointUrl: String) = s"/$context$endpointUrl"
+  private def createLink(endpointUrl: String) = s"$context$endpointUrl"
 
   def discoverTaxYearsHref(utr: SaUtr): String =
     createLink(uk.gov.hmrc.selfassessmentapi.controllers.live.routes.TaxYearsDiscoveryController.discoverTaxYears(utr).url)

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/SourceController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/SourceController.scala
@@ -30,7 +30,7 @@ import scala.concurrent.Future
 
 trait SourceController extends BaseController with Links with SourceTypeSupport {
 
-  override lazy val context: String = AppContext.apiGatewayContext
+  override lazy val context: String = AppContext.apiGatewayLinkContext
 
   protected def createSource(request: Request[JsValue], saUtr: SaUtr, taxYear: TaxYear, sourceType: SourceType) = {
     sourceHandler(sourceType).create(saUtr, taxYear, request.body) match {

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/SummaryController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/SummaryController.scala
@@ -30,7 +30,7 @@ import scala.concurrent.Future
 
 trait SummaryController extends BaseController with Links with SourceTypeSupport {
 
-  override lazy val context: String = AppContext.apiGatewayContext
+  override lazy val context: String = AppContext.apiGatewayLinkContext
 
   def handler(sourceType: SourceType, summaryTypeName: String): SummaryHandler[_] = {
     val summaryType = sourceType.summaryTypes.find(_.name == summaryTypeName)

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/definition/DocumentationController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/definition/DocumentationController.scala
@@ -54,7 +54,7 @@ object Documentation extends BaseController with Links {
 
   case class EndpointDocumentation(name: String, view: Xml)
 
-  override val context: String = AppContext.apiGatewayContext
+  override val context: String = AppContext.apiGatewayLinkContext
 
   private val sourceId: SourceId = "00d2d32d"
   private val summaryId: SourceId = "00d2d98a"

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/definition/SelfAssessmentApiDefinition.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/definition/SelfAssessmentApiDefinition.scala
@@ -191,6 +191,6 @@ class SelfAssessmentApiDefinition(apiContext: String, apiStatus: APIStatus) {
   }
 }
 
-object PublishedSelfAssessmentApiDefinition extends SelfAssessmentApiDefinition(AppContext.apiGatewayContext, APIStatus.PUBLISHED)
+object PublishedSelfAssessmentApiDefinition extends SelfAssessmentApiDefinition(AppContext.apiGatewayRegistrationContext, APIStatus.PUBLISHED)
 
-object PrototypedSelfAssessmentApiDefinition extends SelfAssessmentApiDefinition(AppContext.apiGatewayContext, APIStatus.PROTOTYPED)
+object PrototypedSelfAssessmentApiDefinition extends SelfAssessmentApiDefinition(AppContext.apiGatewayRegistrationContext, APIStatus.PROTOTYPED)

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/live/CustomerResolverController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/live/CustomerResolverController.scala
@@ -26,7 +26,7 @@ import scala.concurrent.Future
 
 case object CustomerResolverController extends uk.gov.hmrc.selfassessmentapi.controllers.CustomerResolverController {
   override val confidenceLevel: ConfidenceLevel = MicroserviceAuthFilter.authParamsConfig.authConfig(this.productPrefix).confidenceLevel
-  override val context: String = AppContext.apiGatewayContext
+  override val context: String = AppContext.apiGatewayLinkContext
 
   override def saUtr(confidenceLevel: ConfidenceLevel)(implicit hc: HeaderCarrier): Future[Option[SaUtr]] =
     if(AppContext.authEnabled) AuthConnector.saUtr(confidenceLevel) else super.saUtr(confidenceLevel)

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/live/LiabilityController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/live/LiabilityController.scala
@@ -29,7 +29,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 object LiabilityController extends uk.gov.hmrc.selfassessmentapi.controllers.LiabilityController {
 
-  override val context: String = AppContext.apiGatewayContext
+  override val context: String = AppContext.apiGatewayLinkContext
 
   private val liabilityService = LiabilityService()
 

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/live/TaxYearDiscoveryController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/live/TaxYearDiscoveryController.scala
@@ -34,7 +34,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 object TaxYearDiscoveryController extends BaseController with Links {
-  override val context: String = AppContext.apiGatewayContext
+  override val context: String = AppContext.apiGatewayLinkContext
   val repository = SelfAssessmentRepository()
 
   final def discoverTaxYear(utr: SaUtr, taxYear: TaxYear) = Action.async { request =>

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/live/TaxYearsDiscoveryController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/live/TaxYearsDiscoveryController.scala
@@ -19,5 +19,5 @@ package uk.gov.hmrc.selfassessmentapi.controllers.live
 import uk.gov.hmrc.selfassessmentapi.config.AppContext
 
 object TaxYearsDiscoveryController extends uk.gov.hmrc.selfassessmentapi.controllers.TaxYearsDiscoveryController {
-  override val context: String = AppContext.apiGatewayContext
+  override val context: String = AppContext.apiGatewayLinkContext
 }

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/sandbox/CustomerResolverController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/sandbox/CustomerResolverController.scala
@@ -22,5 +22,5 @@ import uk.gov.hmrc.selfassessmentapi.config.{AppContext, MicroserviceAuthFilter}
 
 case object CustomerResolverController extends uk.gov.hmrc.selfassessmentapi.controllers.CustomerResolverController {
   override val confidenceLevel: ConfidenceLevel = MicroserviceAuthFilter.authParamsConfig.authConfig(this.productPrefix).confidenceLevel
-  override val context: String = AppContext.apiGatewayContext
+  override val context: String = AppContext.apiGatewayLinkContext
 }

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/sandbox/LiabilityController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/sandbox/LiabilityController.scala
@@ -28,7 +28,7 @@ import scala.concurrent.Future
 
 object LiabilityController extends uk.gov.hmrc.selfassessmentapi.controllers.LiabilityController {
 
-  override val context: String = AppContext.apiGatewayContext
+  override val context: String = AppContext.apiGatewayLinkContext
 
   override def requestLiability(utr: SaUtr, taxYear: TaxYear) = Action.async { request =>
       val links = Set(

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/sandbox/TaxYearDiscoveryController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/sandbox/TaxYearDiscoveryController.scala
@@ -34,7 +34,7 @@ import uk.gov.hmrc.selfassessmentapi.views.Helpers._
 import scala.concurrent.Future
 
 object TaxYearDiscoveryController extends BaseController with Links {
-  override val context: String = AppContext.apiGatewayContext
+  override val context: String = AppContext.apiGatewayLinkContext
 
   final def discoverTaxYear(utr: SaUtr, taxYear: TaxYear) = Action.async { request =>
     Future.successful(Ok(halResource(toJson(TaxYearProperties.example()), discoveryLinks(utr, taxYear))))

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/sandbox/TaxYearsDiscoveryController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/sandbox/TaxYearsDiscoveryController.scala
@@ -19,5 +19,5 @@ package uk.gov.hmrc.selfassessmentapi.controllers.sandbox
 import uk.gov.hmrc.selfassessmentapi.config.AppContext
 
 object TaxYearsDiscoveryController extends uk.gov.hmrc.selfassessmentapi.controllers.TaxYearsDiscoveryController {
-  override val context: String = AppContext.apiGatewayContext
+  override val context: String = AppContext.apiGatewayLinkContext
 }

--- a/app/uk/gov/hmrc/selfassessmentapi/views/Helpers.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/views/Helpers.scala
@@ -29,7 +29,7 @@ import scala.xml.PCData
 
 object Helpers extends HalSupport with Links {
 
-  override val context: String = AppContext.apiGatewayContext
+  override val context: String = AppContext.apiGatewayLinkContext
 
   def sourceTypeAndSummaryTypeResponse(utr: SaUtr, taxYear: TaxYear,  sourceId: SourceId, summaryId: SummaryId) =
     sourceTypeAndSummaryTypeIdResponse(obj(), utr, taxYear, SourceTypes.SelfEmployments, sourceId, selfemployment.SummaryTypes.Incomes, summaryId)


### PR DESCRIPTION
The tactical sandbox may not have /self-assessment in the path, so we need the availability to specify the API context as being empty so that the HAL links are correct.