### PR TITLE
[MTDSA-512] Income tax calculation values should be rounded down to pennies rather than pounds.

### DIFF
--- a/app/uk/gov/hmrc/selfassessmentapi/repositories/domain/MongoLiability.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/repositories/domain/MongoLiability.scala
@@ -153,7 +153,7 @@ case class TaxBandAllocation(amount: BigDecimal, taxBand: TaxBand) {
   def toTaxBandSummary(chargedAt: BigDecimal) =
     uk.gov.hmrc.selfassessmentapi.domain.TaxBandSummary(taxBand.name, amount, s"$chargedAt%", tax(chargedAt))
 
-  def tax(chargedAt: BigDecimal): BigDecimal = roundDown(amount * chargedAt / 100)
+  def tax(chargedAt: BigDecimal): BigDecimal = roundDownToPennies(amount * chargedAt / 100)
 
   def available: BigDecimal = positiveOrZero(taxBand.width - amount)
 

--- a/app/uk/gov/hmrc/selfassessmentapi/services/live/calculation/steps/Math.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/services/live/calculation/steps/Math.scala
@@ -42,4 +42,6 @@ object Math {
   def roundDownToNearest(n: BigDecimal, v: Int): BigDecimal = roundDown(n / v) * v
 
   def roundUp(n: BigDecimal): BigDecimal = n.setScale(0, RoundingMode.UP)
+
+  def roundDownToPennies(n: BigDecimal): BigDecimal = n.setScale(2, RoundingMode.FLOOR)
 }

--- a/test/uk/gov/hmrc/selfassessmentapi/repositories/domain/MongoLiabilitySpec.scala
+++ b/test/uk/gov/hmrc/selfassessmentapi/repositories/domain/MongoLiabilitySpec.scala
@@ -228,4 +228,10 @@ class MongoLiabilitySpec extends UnitSpec with SelfAssessmentSugar with JsonSpec
 
     }
   }
+
+  "TaxBandAllocation.tax" should {
+    "round down the tax due to the nearest penny" in {
+      TaxBandAllocation(300.3333, TaxBand.BasicTaxBand).tax(20) shouldBe 60.06
+    }
+  }
 }


### PR DESCRIPTION
- Add new function `roundDownToPennies`.
- Update tests to reflect this new behaviour.