### PR TITLE
[MTDSA-573] Fix flaky tests by increasing the default timeout duration for Future.

### DIFF
--- a/test/uk/gov/hmrc/selfassessmentapi/UnitSpec.scala
+++ b/test/uk/gov/hmrc/selfassessmentapi/UnitSpec.scala
@@ -19,13 +19,17 @@ package uk.gov.hmrc.selfassessmentapi
 import uk.gov.hmrc.domain.{SaUtr, SaUtrGenerator}
 import uk.gov.hmrc.selfassessmentapi.domain.TaxYear
 
+import scala.concurrent.duration._
+
 trait UnitSpec extends uk.gov.hmrc.play.test.UnitSpec {
+
+  override implicit val defaultTimeout: FiniteDuration = 30 seconds
 
   implicit def taxYearToString(taxYear: TaxYear): String = taxYear.value
 
   private val saUtrGenerator = new SaUtrGenerator()
 
-  def generateSaUtr(): SaUtr = saUtrGenerator.nextSaUtr
+  def generateSaUtr() = saUtrGenerator.nextSaUtr
 
   val taxYear = TaxYear("2016-17")
 


### PR DESCRIPTION
- Override defaultTimeout in UnitSpec to 30 seconds, up from 5.
- Change default timeout duration to 30 seconds in the `Http` class.