### PR TITLE
[MTDSA-449] Fix issue where the source id was being taken from the TaxPaid class, rather than the UkProperty class.

### DIFF
--- a/app/uk/gov/hmrc/selfassessmentapi/domain/Liability.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/Liability.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.selfassessmentapi.domain
 import play.api.libs.json.Json
 import uk.gov.hmrc.selfassessmentapi.config.{AppContext, FeatureSwitch}
 import uk.gov.hmrc.selfassessmentapi.repositories.domain.{EmploymentIncome, FurnishedHolidayLettingIncome, SelfEmploymentIncome, UkPropertyIncome}
-import uk.gov.hmrc.selfassessmentapi.domain.ukproperty.TaxPaid
 
 case class InterestFromUKBanksAndBuildingSocieties(sourceId: String, totalInterest: BigDecimal)
 
@@ -107,8 +106,14 @@ object UkTaxPaidForEmployment {
   implicit val format = Json.format[UkTaxPaidForEmployment]
 }
 
+case class TaxPaidForUkProperty(sourceId: String, amount: BigDecimal)
+
+object TaxPaidForUkProperty {
+  implicit val format = Json.format[TaxPaidForUkProperty]
+}
+
 case class TaxDeducted(interestFromUk: BigDecimal,
-                       fromUkProperties: Seq[TaxPaid],
+                       fromUkProperties: Seq[TaxPaidForUkProperty],
                        fromEmployments: Seq[UkTaxPaidForEmployment],
                        total: BigDecimal)
 

--- a/app/uk/gov/hmrc/selfassessmentapi/repositories/domain/MongoLiability.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/repositories/domain/MongoLiability.scala
@@ -23,7 +23,6 @@ import uk.gov.hmrc.domain.SaUtr
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 import uk.gov.hmrc.selfassessmentapi.domain.ErrorCode._
 import uk.gov.hmrc.selfassessmentapi.domain._
-import uk.gov.hmrc.selfassessmentapi.domain.ukproperty.TaxPaid
 import uk.gov.hmrc.selfassessmentapi.repositories.domain.TaxBand.{AdditionalHigherTaxBand, BasicTaxBand, HigherTaxBand, NilTaxBand, SavingsStartingTaxBand}
 import uk.gov.hmrc.selfassessmentapi.services.live.calculation.steps.Math._
 
@@ -174,7 +173,7 @@ case class MongoUkTaxPaidForEmployment(sourceId: SourceId, ukTaxPaid: BigDecimal
 
 case class MongoTaxDeducted(interestFromUk: BigDecimal = 0,
                             totalDeductionFromUkProperties: BigDecimal = 0,
-                            deductionFromUkProperties: Seq[TaxPaid] = Nil,
+                            deductionFromUkProperties: Seq[TaxPaidForUkProperty] = Nil,
                             ukTaxPaid: BigDecimal = 0,
                             ukTaxesPaidForEmployments: Seq[MongoUkTaxPaidForEmployment] = Nil) {
 

--- a/app/uk/gov/hmrc/selfassessmentapi/services/live/calculation/steps/TaxDeductedForUkPropertiesCalculation.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/services/live/calculation/steps/TaxDeductedForUkPropertiesCalculation.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.selfassessmentapi.services.live.calculation.steps
 
-import uk.gov.hmrc.selfassessmentapi.domain.ukproperty.TaxPaid
+import uk.gov.hmrc.selfassessmentapi.domain.TaxPaidForUkProperty
 import uk.gov.hmrc.selfassessmentapi.repositories.domain._
 import uk.gov.hmrc.selfassessmentapi.services.live.calculation.steps.Math._
 
@@ -36,10 +36,10 @@ object TaxDeductedForUkPropertiesCalculation extends CalculationStep {
     roundUp(selfAssessment.ukProperties.map(_.taxPaid).sum)
   }
 
-  private def taxDeductedPerUkProperty(selfAssessment: SelfAssessment): Seq[TaxPaid] = {
+  private def taxDeductedPerUkProperty(selfAssessment: SelfAssessment): Seq[TaxPaidForUkProperty] = {
     for {
       property <- selfAssessment.ukProperties
       taxPaid <- property.taxesPaid
-    } yield taxPaid.toTaxPaid
+    } yield TaxPaidForUkProperty(property.sourceId, taxPaid.amount)
   }
 }

--- a/test/uk/gov/hmrc/selfassessmentapi/repositories/domain/MongoLiabilitySpec.scala
+++ b/test/uk/gov/hmrc/selfassessmentapi/repositories/domain/MongoLiabilitySpec.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.selfassessmentapi.repositories.domain
 import uk.gov.hmrc.selfassessmentapi.SelfAssessmentSugar._
 import uk.gov.hmrc.selfassessmentapi.UnitSpec
 import uk.gov.hmrc.selfassessmentapi.domain._
-import uk.gov.hmrc.selfassessmentapi.domain.ukproperty.TaxPaid
 import uk.gov.hmrc.selfassessmentapi.repositories.domain.TaxBand.{AdditionalHigherTaxBand, BasicTaxBand, HigherTaxBand, NilTaxBand, SavingsStartingTaxBand}
 
 class MongoLiabilitySpec extends UnitSpec with JsonSpec {
@@ -184,7 +183,7 @@ class MongoLiabilitySpec extends UnitSpec with JsonSpec {
           taxDeducted = Some(
               MongoTaxDeducted(
                   interestFromUk = 1000,
-                  deductionFromUkProperties = Seq(TaxPaid(Some("property-1"), 500)),
+                  deductionFromUkProperties = Seq(TaxPaidForUkProperty("property-1", 500)),
                   totalDeductionFromUkProperties = 500,
                   ukTaxPaid = 0,
                   ukTaxesPaidForEmployments = Nil

--- a/test/uk/gov/hmrc/selfassessmentapi/services/live/calculation/steps/TaxDeductedForUkPropertiesCalculationSpec.scala
+++ b/test/uk/gov/hmrc/selfassessmentapi/services/live/calculation/steps/TaxDeductedForUkPropertiesCalculationSpec.scala
@@ -21,6 +21,7 @@ import uk.gov.hmrc.selfassessmentapi.domain.ukproperty.TaxPaid
 import uk.gov.hmrc.selfassessmentapi.SelfAssessmentSugar._
 import uk.gov.hmrc.selfassessmentapi.UkPropertySugar._
 import uk.gov.hmrc.selfassessmentapi.UnitSpec
+import uk.gov.hmrc.selfassessmentapi.domain.TaxPaidForUkProperty
 import uk.gov.hmrc.selfassessmentapi.repositories.domain.MongoTaxDeducted
 
 class TaxDeductedForUkPropertiesCalculationSpec extends UnitSpec with TableDrivenPropertyChecks {
@@ -32,11 +33,11 @@ class TaxDeductedForUkPropertiesCalculationSpec extends UnitSpec with TableDrive
 
       TaxDeductedForUkPropertiesCalculation
         .run(aSelfAssessment(
-                 ukProperties = Seq(aUkProperty().copy(taxesPaid = Seq(aTaxPaidSummary("property-1", 500))))),
+                 ukProperties = Seq(aUkProperty(id = "property-1").copy(taxesPaid = Seq(aTaxPaidSummary("property-1", 500))))),
              liability)
         .getLiabilityOrFail shouldBe
         liability.copy(
-            taxDeducted = Some(MongoTaxDeducted(deductionFromUkProperties = Seq(TaxPaid(Some("property-1"), 500)),
+            taxDeducted = Some(MongoTaxDeducted(deductionFromUkProperties = Seq(TaxPaidForUkProperty("property-1", 500)),
                                                 totalDeductionFromUkProperties = 500)))
     }
 
@@ -45,11 +46,11 @@ class TaxDeductedForUkPropertiesCalculationSpec extends UnitSpec with TableDrive
 
       TaxDeductedForUkPropertiesCalculation
         .run(
-            aSelfAssessment(ukProperties = Seq(aUkProperty().copy(taxesPaid = Seq(aTaxPaidSummary("property-1", 500.22))))),
+            aSelfAssessment(ukProperties = Seq(aUkProperty(id = "property-1").copy(taxesPaid = Seq(aTaxPaidSummary("property-1", 500.22))))),
             liability)
         .getLiabilityOrFail shouldBe
         liability.copy(
-            taxDeducted = Some(MongoTaxDeducted(deductionFromUkProperties = Seq(TaxPaid(Some("property-1"), 500.22)),
+            taxDeducted = Some(MongoTaxDeducted(deductionFromUkProperties = Seq(TaxPaidForUkProperty("property-1", 500.22)),
                                                 totalDeductionFromUkProperties = 501)))
     }
   }


### PR DESCRIPTION
- Add a new class, `TaxPaidForUkProperty` which is used to store the property source identifier and amount of tax paid for that property.