### PR TITLE
[MTDSA-578] Add feature switching to individual tax year properties.

### DIFF
--- a/app/uk/gov/hmrc/selfassessmentapi/config/FeatureSwitch.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/config/FeatureSwitch.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.selfassessmentapi.config
 
 import play.api.Configuration
 import uk.gov.hmrc.selfassessmentapi.config.AppContext._
-import uk.gov.hmrc.selfassessmentapi.domain.SourceType
+import uk.gov.hmrc.selfassessmentapi.domain.{SourceType, TaxYearPropertyType}
 
 case class FeatureSwitch(value: Option[Configuration]) {
   val DEFAULT_VALUE = false
@@ -32,6 +32,11 @@ case class FeatureSwitch(value: Option[Configuration]) {
     case Some(config) =>
       if(summary.isEmpty) FeatureConfig(config).isSourceEnabled(sourceType.name)
       else FeatureConfig(config).isSummaryEnabled(sourceType.name, summary)
+    case None => DEFAULT_VALUE
+  }
+
+  def isEnabled(source: TaxYearPropertyType): Boolean = value match {
+    case Some(config) => FeatureConfig(config).isSourceEnabled(source.name)
     case None => DEFAULT_VALUE
   }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -296,6 +296,13 @@ Dev {
     furnished-holiday-lettings.enabled = true
     employments.enabled = true
     uk-properties.enabled = true
+    blindPerson.enabled = true
+    charitableGivings.enabled = true
+    childBenefit.enabled = true
+    pensionContributions.enabled = true
+    studentLoan.enabled = true
+    taxRefundedOrSetOff.enabled = true
+
     white-list {
       enabled = false
       applicationIds = []
@@ -359,6 +366,13 @@ Test {
     furnished-holiday-lettings.enabled = true
     employments.enabled = true
     uk-properties.enabled = true
+    blindPerson.enabled = true
+    charitableGivings.enabled = true
+    childBenefit.enabled = true
+    pensionContributions.enabled = true
+    studentLoan.enabled = true
+    taxRefundedOrSetOff.enabled = true
+
     white-list {
       enabled = false
       applicationIds = []

--- a/test/uk/gov/hmrc/selfassessmentapi/services/DeleteExpiredDataServiceSpec.scala
+++ b/test/uk/gov/hmrc/selfassessmentapi/services/DeleteExpiredDataServiceSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.mock.MockitoSugar
 import org.scalatest.time.{Millis, Seconds, Span}
 import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.selfassessmentapi.MongoEmbeddedDatabase
+import uk.gov.hmrc.selfassessmentapi.config.FeatureSwitch
 import uk.gov.hmrc.selfassessmentapi.domain.selfemployment.SelfEmployment
 import uk.gov.hmrc.selfassessmentapi.repositories.domain.MongoJobStatus._
 import uk.gov.hmrc.selfassessmentapi.repositories.domain.{MongoJobHistory, MongoSelfAssessment, MongoSelfEmployment}
@@ -36,7 +37,8 @@ import scala.concurrent.Future
 
 class DeleteExpiredDataServiceSpec extends MongoEmbeddedDatabase with MockitoSugar with ScalaFutures {
 
-  private val saRepo = new SelfAssessmentMongoRepository
+  private val mockFeatureSwitch = mock[FeatureSwitch]
+  private val saRepo = new SelfAssessmentMongoRepository(mockFeatureSwitch)
   private val seRepo = new SelfEmploymentMongoRepository
   private val uiRepo = new UnearnedIncomeMongoRepository
   private val jobRepo = new JobHistoryMongoRepository


### PR DESCRIPTION
- Modify the `findTaxYearProperties` method to exclude items that are not currently enabled.
- Modify the `FeatureSwitch` class to include an override for `isEnabled` that takes a `TaxYearPropertyType`