### PR TITLE
[MTDSA-578] Add feature switching to individual tax year properties.

### DIFF
--- a/app/uk/gov/hmrc/selfassessmentapi/config/FeatureSwitch.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/config/FeatureSwitch.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.selfassessmentapi.config
 
 import play.api.Configuration
 import uk.gov.hmrc.selfassessmentapi.config.AppContext._
-import uk.gov.hmrc.selfassessmentapi.domain.SourceType
+import uk.gov.hmrc.selfassessmentapi.domain.{SourceType, TaxYearPropertyType}
 
 case class FeatureSwitch(value: Option[Configuration]) {
   val DEFAULT_VALUE = false
@@ -32,6 +32,11 @@ case class FeatureSwitch(value: Option[Configuration]) {
     case Some(config) =>
       if(summary.isEmpty) FeatureConfig(config).isSourceEnabled(sourceType.name)
       else FeatureConfig(config).isSummaryEnabled(sourceType.name, summary)
+    case None => DEFAULT_VALUE
+  }
+
+  def isEnabled(source: TaxYearPropertyType): Boolean = value match {
+    case Some(config) => FeatureConfig(config).isSourceEnabled(source.name)
     case None => DEFAULT_VALUE
   }
 

--- a/app/uk/gov/hmrc/selfassessmentapi/controllers/live/TaxYearDiscoveryController.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/controllers/live/TaxYearDiscoveryController.scala
@@ -19,28 +19,26 @@ package uk.gov.hmrc.selfassessmentapi.controllers.live
 import play.api.hal.HalLink
 import play.api.libs.json.Json
 import play.api.libs.json.Json._
-import play.api.libs.json.{JsArray, Json}
 import play.api.mvc.Action
 import play.api.mvc.hal._
 import uk.gov.hmrc.domain.SaUtr
 import uk.gov.hmrc.selfassessmentapi.config.{AppContext, FeatureConfig}
-import uk.gov.hmrc.selfassessmentapi.controllers.{BaseController, ErrorNotImplemented, Links}
-import uk.gov.hmrc.selfassessmentapi.controllers.{BaseController, InvalidPart, InvalidRequest, Links}
-import uk.gov.hmrc.selfassessmentapi.domain.ErrorCode._
-import uk.gov.hmrc.selfassessmentapi.domain.{ErrorCode, SourceTypes, TaxYear, TaxYearProperties}
-import uk.gov.hmrc.selfassessmentapi.repositories.SelfAssessmentRepository
+import uk.gov.hmrc.selfassessmentapi.controllers.ErrorNotImplemented
+import uk.gov.hmrc.selfassessmentapi.controllers.{BaseController, Links}
+import uk.gov.hmrc.selfassessmentapi.domain.{SourceTypes, TaxYear, TaxYearProperties}
+import uk.gov.hmrc.selfassessmentapi.services.TaxYearPropertiesService
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 object TaxYearDiscoveryController extends BaseController with Links {
   override val context: String = AppContext.apiGatewayLinkContext
-  val repository = SelfAssessmentRepository()
+  val taxYearPropertiesService = TaxYearPropertiesService()
 
   final def discoverTaxYear(utr: SaUtr, taxYear: TaxYear) = Action.async { request =>
     val halLinks = buildSourceHalLinks(utr, taxYear) + HalLink("self",
       discoverTaxYearHref(utr, taxYear))
-    repository
+    taxYearPropertiesService
       .findTaxYearProperties(utr, taxYear)
       .map(taxYearProperties =>
         Ok(halResource(taxYearProperties match {
@@ -59,26 +57,13 @@ object TaxYearDiscoveryController extends BaseController with Links {
     }
   }
 
-  private def validateRequest(taxYearProperties: TaxYearProperties, taxYear: String)  = {
-    if (taxYearProperties.charitableGivings.isDefined || taxYearProperties.blindPerson.isDefined ||
-      taxYearProperties.studentLoan.isDefined || taxYearProperties.taxRefundedOrSetOff.isDefined ||
-      taxYearProperties.childBenefit.isDefined) {
-      Some(
-            InvalidPart(ONLY_PENSION_CONTRIBUTIONS_SUPPORTED, s"Only update of Pension Contributions is supported", "/taxYearProperties"))
-    } else None
-  }
-
   final def updateTaxYearProperties(utr: SaUtr, taxYear: TaxYear) =
     Action.async(parse.json) {
       implicit request =>
         if (AppContext.updateTaxYearPropertiesEnabled)
           withJsonBody[TaxYearProperties] { taxYearProperties =>
-            validateRequest(taxYearProperties, taxYear.taxYear) match {
-              case Some(invalidPart) => Future.successful(BadRequest(Json.toJson(InvalidRequest(ErrorCode.INVALID_REQUEST, "Invalid request", Seq(invalidPart)))))
-              case None =>
-                repository.updateTaxYearProperties(utr, taxYear, taxYearProperties).map { x =>
-                  Ok(halResource(obj(), buildSourceHalLinks(utr, taxYear)))
-                }
+            taxYearPropertiesService.updateTaxYearProperties(utr, taxYear, taxYearProperties).map { _ =>
+              Ok(halResource(obj(), buildSourceHalLinks(utr, taxYear)))
             }
           }
         else Future.successful(NotImplemented(Json.toJson(ErrorNotImplemented)))

--- a/app/uk/gov/hmrc/selfassessmentapi/repositories/SelfAssessmentRepository.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/repositories/SelfAssessmentRepository.scala
@@ -31,7 +31,6 @@ import uk.gov.hmrc.selfassessmentapi.repositories.domain.MongoSelfAssessment
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-
 object SelfAssessmentRepository extends MongoDbConnection {
   private lazy val repository = new SelfAssessmentMongoRepository
 
@@ -126,11 +125,12 @@ class SelfAssessmentMongoRepository(implicit mongo: () => DB)
     } yield ()
   }
 
-  def findTaxYearProperties(saUtr: SaUtr, taxYear: TaxYear): Future[Option[TaxYearProperties]] =
+  def findTaxYearProperties(saUtr: SaUtr, taxYear: TaxYear): Future[Option[TaxYearProperties]] = {
     for {
       optionSa <- find("saUtr" -> saUtr.utr, "taxYear" -> taxYear.taxYear).map(_.headOption)
     } yield for {
       sa <- optionSa
       taxYearProperties <- sa.taxYearProperties
     } yield taxYearProperties
+  }
 }

--- a/app/uk/gov/hmrc/selfassessmentapi/services/TaxYearPropertiesService.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/services/TaxYearPropertiesService.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.selfassessmentapi.services
+
+import uk.gov.hmrc.domain.SaUtr
+import uk.gov.hmrc.selfassessmentapi.config.{AppContext, FeatureSwitch}
+import uk.gov.hmrc.selfassessmentapi.domain.blindperson.BlindPersons
+import uk.gov.hmrc.selfassessmentapi.domain.charitablegiving.CharitableGivings
+import uk.gov.hmrc.selfassessmentapi.domain.childbenefit.ChildBenefits
+import uk.gov.hmrc.selfassessmentapi.domain.pensioncontribution.PensionContributions
+import uk.gov.hmrc.selfassessmentapi.domain.studentsloan.StudentLoans
+import uk.gov.hmrc.selfassessmentapi.domain.taxrefundedorsetoff.TaxRefundedOrSetOffs
+import uk.gov.hmrc.selfassessmentapi.domain.{TaxYear, TaxYearProperties, TaxYearPropertyType}
+import uk.gov.hmrc.selfassessmentapi.repositories.{SelfAssessmentMongoRepository, SelfAssessmentRepository}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class TaxYearPropertiesService(saRepository: SelfAssessmentMongoRepository, featureSwitch: FeatureSwitch) {
+
+  def taxYearPropertyIsEnabled(propertyType: TaxYearPropertyType): Boolean = {
+    featureSwitch.isEnabled(propertyType)
+  }
+
+  def findTaxYearProperties(saUtr: SaUtr, taxYear: TaxYear): Future[Option[TaxYearProperties]] = {
+    for {
+      propertiesOption <- saRepository.findTaxYearProperties(saUtr, taxYear)
+    } yield for {
+      properties <- propertiesOption
+    } yield switchedTaxYearProperties(properties)
+  }
+
+  def updateTaxYearProperties(saUtr: SaUtr, taxYear: TaxYear, taxYearProperties: TaxYearProperties): Future[Unit] = {
+    val switchedProperties = switchedTaxYearProperties(taxYearProperties)
+
+    saRepository.updateTaxYearProperties(saUtr, taxYear, switchedProperties)
+  }
+
+  private def switchedTaxYearProperties(properties: TaxYearProperties): TaxYearProperties = {
+    val pensionContributions = if (taxYearPropertyIsEnabled(PensionContributions)) properties.pensionContributions else None
+    val charitableGivings = if (taxYearPropertyIsEnabled(CharitableGivings)) properties.charitableGivings else None
+    val blindPersons = if (taxYearPropertyIsEnabled(BlindPersons)) properties.blindPerson else None
+    val studentLoans = if (taxYearPropertyIsEnabled(StudentLoans)) properties.studentLoan else None
+    val taxRefundedOrSetOffs = if (taxYearPropertyIsEnabled(TaxRefundedOrSetOffs)) properties.taxRefundedOrSetOff else None
+    val childBenefits = if (taxYearPropertyIsEnabled(ChildBenefits)) properties.childBenefit else None
+
+    TaxYearProperties(pensionContributions = pensionContributions, charitableGivings = charitableGivings, blindPerson = blindPersons,
+      studentLoan = studentLoans, taxRefundedOrSetOff = taxRefundedOrSetOffs, childBenefit = childBenefits)
+  }
+}
+
+object TaxYearPropertiesService {
+  private val taxYearPropertiesService = new TaxYearPropertiesService(SelfAssessmentRepository(),
+                                                                      FeatureSwitch(AppContext.featureSwitch))
+
+  def apply() = taxYearPropertiesService
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -296,6 +296,13 @@ Dev {
     furnished-holiday-lettings.enabled = true
     employments.enabled = true
     uk-properties.enabled = true
+    blindPerson.enabled = false
+    charitableGivings.enabled = false
+    childBenefit.enabled = false
+    pensionContributions.enabled = true
+    studentLoan.enabled = false
+    taxRefundedOrSetOff.enabled = false
+
     white-list {
       enabled = false
       applicationIds = []
@@ -359,6 +366,13 @@ Test {
     furnished-holiday-lettings.enabled = true
     employments.enabled = true
     uk-properties.enabled = true
+    blindPerson.enabled = false
+    charitableGivings.enabled = false
+    childBenefit.enabled = false
+    pensionContributions.enabled = true
+    studentLoan.enabled = false
+    taxRefundedOrSetOff.enabled = false
+
     white-list {
       enabled = false
       applicationIds = []

--- a/func/uk/gov/hmrc/selfassessmentapi/TaxYearValidationSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/TaxYearValidationSpec.scala
@@ -4,7 +4,6 @@ import play.api.libs.json.Json
 import play.api.test.FakeApplication
 import uk.gov.hmrc.selfassessmentapi.domain.ErrorCode._
 import uk.gov.hmrc.support.BaseFunctionalSpec
-import uk.gov.hmrc.support.BaseFunctionalSpec
 
 // FIXME: Refactor into live and sandbox tests
 
@@ -243,4 +242,3 @@ class TaxYearFeatureSwitchOffSpec extends BaseFunctionalSpec {
     }
   }
 }
-

--- a/test/uk/gov/hmrc/selfassessmentapi/domain/LiabilitySpec.scala
+++ b/test/uk/gov/hmrc/selfassessmentapi/domain/LiabilitySpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.selfassessmentapi.domain
 
 import org.json.{JSONArray, JSONObject}

--- a/test/uk/gov/hmrc/selfassessmentapi/repositories/SelfAssessmentRepositorySpec.scala
+++ b/test/uk/gov/hmrc/selfassessmentapi/repositories/SelfAssessmentRepositorySpec.scala
@@ -21,8 +21,8 @@ import org.scalatest.BeforeAndAfterEach
 import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.domain.SaUtr
 import uk.gov.hmrc.selfassessmentapi.MongoEmbeddedDatabase
-import uk.gov.hmrc.selfassessmentapi.domain.TaxYearProperties
 import uk.gov.hmrc.selfassessmentapi.domain.pensioncontribution.{PensionContribution, PensionSaving}
+import uk.gov.hmrc.selfassessmentapi.domain.TaxYearProperties
 import uk.gov.hmrc.selfassessmentapi.repositories.domain.MongoSelfAssessment
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/test/uk/gov/hmrc/selfassessmentapi/services/TaxYearPropertiesServiceSpec.scala
+++ b/test/uk/gov/hmrc/selfassessmentapi/services/TaxYearPropertiesServiceSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.selfassessmentapi.services
+
+import org.mockito.Matchers.{eq => matchEq, any}
+import org.mockito.Mockito.{times, when, verify}
+import org.scalatest.mock.MockitoSugar
+
+import uk.gov.hmrc.domain.SaUtr
+import uk.gov.hmrc.selfassessmentapi.UnitSpec
+import uk.gov.hmrc.selfassessmentapi.config.FeatureSwitch
+import uk.gov.hmrc.selfassessmentapi.domain.{TaxYear, TaxYearProperties}
+import uk.gov.hmrc.selfassessmentapi.domain.blindperson.BlindPersons
+import uk.gov.hmrc.selfassessmentapi.domain.charitablegiving.CharitableGivings
+import uk.gov.hmrc.selfassessmentapi.domain.childbenefit.ChildBenefits
+import uk.gov.hmrc.selfassessmentapi.domain.pensioncontribution.PensionContributions
+import uk.gov.hmrc.selfassessmentapi.domain.studentsloan.StudentLoans
+import uk.gov.hmrc.selfassessmentapi.domain.taxrefundedorsetoff.TaxRefundedOrSetOffs
+import uk.gov.hmrc.selfassessmentapi.repositories.SelfAssessmentMongoRepository
+
+class TaxYearPropertiesServiceSpec extends UnitSpec with MockitoSugar {
+  val mockSaRepository = mock[SelfAssessmentMongoRepository]
+  val mockFeatureSwitch = mock[FeatureSwitch]
+
+  val unitUnderTest = new TaxYearPropertiesService(mockSaRepository, mockFeatureSwitch)
+
+  "TaxYearPropertiesService.findTaxYearProperties" should {
+    "only include properties that have been enabled" in {
+      when(mockFeatureSwitch.isEnabled(PensionContributions)).thenReturn(true)
+      when(mockFeatureSwitch.isEnabled(CharitableGivings)).thenReturn(true)
+      when(mockFeatureSwitch.isEnabled(BlindPersons)).thenReturn(true)
+      when(mockFeatureSwitch.isEnabled(StudentLoans)).thenReturn(false)
+      when(mockFeatureSwitch.isEnabled(TaxRefundedOrSetOffs)).thenReturn(false)
+      when(mockFeatureSwitch.isEnabled(ChildBenefits)).thenReturn(false)
+
+      val properties = TaxYearProperties.example()
+
+      when(mockSaRepository.findTaxYearProperties(any[SaUtr], any[TaxYear])).thenReturn(Some(properties))
+
+      val expected = Some(properties.copy(studentLoan = None, taxRefundedOrSetOff = None, childBenefit = None))
+      val actual = await(unitUnderTest.findTaxYearProperties(generateSaUtr(), taxYear))
+
+      expected shouldBe actual
+    }
+  }
+
+  "TaxYearPropertiesService.updateTaxYearProperties" should {
+    "only include properties that have been enabled" in {
+      when(mockFeatureSwitch.isEnabled(PensionContributions)).thenReturn(true)
+      when(mockFeatureSwitch.isEnabled(CharitableGivings)).thenReturn(true)
+      when(mockFeatureSwitch.isEnabled(BlindPersons)).thenReturn(true)
+      when(mockFeatureSwitch.isEnabled(StudentLoans)).thenReturn(false)
+      when(mockFeatureSwitch.isEnabled(TaxRefundedOrSetOffs)).thenReturn(false)
+      when(mockFeatureSwitch.isEnabled(ChildBenefits)).thenReturn(false)
+
+      val properties = TaxYearProperties.example()
+
+      when(mockSaRepository.findTaxYearProperties(any[SaUtr], any[TaxYear])).thenReturn(Some(properties))
+
+      val expected = properties.copy(studentLoan = None, taxRefundedOrSetOff = None, childBenefit = None)
+
+      unitUnderTest.updateTaxYearProperties(generateSaUtr(), taxYear, properties)
+
+      verify(mockSaRepository, times(1)).updateTaxYearProperties(any[SaUtr], any[TaxYear], matchEq(expected))
+    }
+  }
+}


### PR DESCRIPTION
- Uncouple the `TaxYearDiscoveryController` and `SelfAssessmentMongoRepository` by adding a new `TaxYearPropertiesService` that is used by the controller to interact with the underlying data store.
