### PR TITLE
[JTH][MTDSA-759] Implement creation of self-employment source.

### DIFF
--- a/app/uk/gov/hmrc/selfassessmentapi/domain/SelfEmployment.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/domain/SelfEmployment.scala
@@ -33,7 +33,7 @@ case class SelfEmployment(id: BSONObjectID,
                           lastModifiedDateTime: LocalDate,
                           accountingPeriod: AccountingPeriod,
                           accountingType: AccountingType,
-                          commencementDate: LocalDate,
+                          commencementDate: Option[LocalDate],
                           annualSummaries: Map[TaxYear, SelfEmploymentAnnualSummary] = Map.empty,
                           periods: Map[PeriodId, SelfEmploymentPeriod] = Map.empty)
     extends PeriodValidator[SelfEmploymentPeriod]

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/models/selfemployment/SelfEmployment.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/models/selfemployment/SelfEmployment.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.selfassessmentapi.resources.models.AccountingType._
 case class SelfEmployment(id: Option[SourceId] = None,
                           accountingPeriod: AccountingPeriod,
                           accountingType: AccountingType,
-                          commencementDate: LocalDate)
+                          commencementDate: Option[LocalDate])
 
 object SelfEmployment {
 
@@ -40,6 +40,6 @@ object SelfEmployment {
     Reads.pure(None) and
       (__ \ "accountingPeriod").read[AccountingPeriod] and
       (__ \ "accountingType").read[AccountingType] and
-      (__ \ "commencementDate").read[LocalDate](commencementDateValidator)
+      (__ \ "commencementDate").readNullable[LocalDate](commencementDateValidator)
     ) (SelfEmployment.apply _)
 }

--- a/func/uk/gov/hmrc/selfassessmentapi/featureswitch/SelfEmploymentAnnualSummaryFeatureSwitchSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/featureswitch/SelfEmploymentAnnualSummaryFeatureSwitchSpec.scala
@@ -21,7 +21,7 @@ class SelfEmploymentAnnualSummaryFeatureSwitchSpec extends BaseFunctionalSpec {
       val selfEmployment = Json.toJson(SelfEmployment(
         accountingPeriod = AccountingPeriod(LocalDate.parse("2017-04-01"), LocalDate.parse("2017-04-02")),
         accountingType = AccountingType.CASH,
-        commencementDate = LocalDate.now.minusDays(1)))
+        commencementDate = Some(LocalDate.now.minusDays(1))))
 
       given()
         .userIsAuthorisedForTheResource(nino)

--- a/func/uk/gov/hmrc/selfassessmentapi/featureswitch/SelfEmploymentPeriodicSummaryFeatureSwitchSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/featureswitch/SelfEmploymentPeriodicSummaryFeatureSwitchSpec.scala
@@ -25,7 +25,7 @@ class SelfEmploymentPeriodicSummaryFeatureSwitchSpec extends BaseFunctionalSpec 
       val selfEmployment = Json.toJson(SelfEmployment(
         accountingPeriod = AccountingPeriod(LocalDate.parse("2017-04-01"), LocalDate.parse("2017-04-02")),
         accountingType = AccountingType.CASH,
-        commencementDate = LocalDate.now.minusDays(1)))
+        commencementDate = Some(LocalDate.now.minusDays(1))))
 
       given()
         .userIsAuthorisedForTheResource(nino)

--- a/public/api/conf/1.0/schemas/Income.json
+++ b/public/api/conf/1.0/schemas/Income.json
@@ -15,5 +15,8 @@
       "minimum": 0
     }
   },
+  "required": [
+    "amount"
+  ],
   "additionalProperties": false
 }

--- a/test/uk/gov/hmrc/selfassessmentapi/repositories/SelfEmploymentRepositorySpec.scala
+++ b/test/uk/gov/hmrc/selfassessmentapi/repositories/SelfEmploymentRepositorySpec.scala
@@ -30,7 +30,7 @@ class SelfEmploymentRepositorySpec extends MongoEmbeddedDatabase {
   private val repo = new SelfEmploymentsRepository
   private val id = BSONObjectID.generate
   private val selfEmployment = SelfEmployment(id, id.stringify, nino, LocalDate.now(DateTimeZone.UTC),
-    AccountingPeriod(LocalDate.parse("2017-04-01"), LocalDate.parse("2017-04-02")), AccountingType.CASH, LocalDate.now(DateTimeZone.UTC))
+    AccountingPeriod(LocalDate.parse("2017-04-01"), LocalDate.parse("2017-04-02")), AccountingType.CASH, Some(LocalDate.now(DateTimeZone.UTC)))
 
   "create" should {
     "create a self employment with a non-null id" in {
@@ -50,7 +50,7 @@ class SelfEmploymentRepositorySpec extends MongoEmbeddedDatabase {
 
     "overwrite existing fields in self-employment with new data provided by the user" in {
       await(repo.create(selfEmployment))
-      val updatedSelfEmployment = selfEmployment.copy(commencementDate = now.toLocalDate.plusDays(1))
+      val updatedSelfEmployment = selfEmployment.copy(commencementDate = Some(now.toLocalDate.plusDays(1)))
 
       await(repo.update(id.stringify, nino, updatedSelfEmployment)) shouldBe true
 
@@ -98,7 +98,7 @@ class SelfEmploymentRepositorySpec extends MongoEmbeddedDatabase {
     "return a sequence of self employments" in {
       val id2 = BSONObjectID.generate
       val selfEmploymentTwo = SelfEmployment(id2, id2.stringify, nino, LocalDate.now(DateTimeZone.UTC),
-        AccountingPeriod(LocalDate.parse("2017-04-01"), LocalDate.parse("2017-04-02")), AccountingType.CASH, LocalDate.now(DateTimeZone.UTC))
+        AccountingPeriod(LocalDate.parse("2017-04-01"), LocalDate.parse("2017-04-02")), AccountingType.CASH, Some(LocalDate.now(DateTimeZone.UTC)))
 
       await(repo.create(selfEmployment))
       await(repo.create(selfEmploymentTwo))

--- a/test/uk/gov/hmrc/selfassessmentapi/resources/models/selfemployment/SelfEmploymentSpec.scala
+++ b/test/uk/gov/hmrc/selfassessmentapi/resources/models/selfemployment/SelfEmploymentSpec.scala
@@ -28,26 +28,26 @@ class SelfEmploymentSpec extends JsonSpec {
 
   "SelfEmployment JSON" should {
     "round ignore the id if it is provided by the user" in {
-      val input = SelfEmployment(Some("myid"), AccountingPeriod(LocalDate.parse("2017-04-01"), LocalDate.parse("2017-04-02")), AccountingType.CASH, LocalDate.now.minusDays(1))
+      val input = SelfEmployment(Some("myid"), AccountingPeriod(LocalDate.parse("2017-04-01"), LocalDate.parse("2017-04-02")), AccountingType.CASH, Some(LocalDate.now.minusDays(1)))
       val expectedOutput = input.copy(id = None)
 
       assertJsonIs(input, expectedOutput)
     }
 
     "return a COMMENCEMENT_DATE_NOT_IN_THE_PAST error when using a commencement date in the future" in {
-      val input = SelfEmployment(None, AccountingPeriod(LocalDate.parse("2017-04-01"), LocalDate.parse("2017-04-02")), AccountingType.CASH, LocalDate.now.plusDays(1))
+      val input = SelfEmployment(None, AccountingPeriod(LocalDate.parse("2017-04-01"), LocalDate.parse("2017-04-02")), AccountingType.CASH, Some(LocalDate.now.plusDays(1)))
       assertValidationErrorWithCode(input,
         "/commencementDate", ErrorCode.DATE_NOT_IN_THE_PAST)
     }
 
     "return a INVALID_ACCOUNTING_PERIOD error when startDate < endDate" in {
-      val input = SelfEmployment(None, AccountingPeriod(LocalDate.parse("2017-04-02"), LocalDate.parse("2017-04-01")), AccountingType.CASH, LocalDate.now.minusDays(1))
+      val input = SelfEmployment(None, AccountingPeriod(LocalDate.parse("2017-04-02"), LocalDate.parse("2017-04-01")), AccountingType.CASH, Some(LocalDate.now.minusDays(1)))
       assertValidationErrorWithCode(input,
         "/accountingPeriod", ErrorCode.INVALID_ACCOUNTING_PERIOD)
     }
 
     "return a DATE_NOT_IN_THE_PAST error when proving an accounting period with a start date that is before 2017-04-01" in {
-      val input = SelfEmployment(None, AccountingPeriod(LocalDate.parse("2017-03-01"), LocalDate.parse("2017-03-03")), AccountingType.CASH, LocalDate.now.minusDays(1))
+      val input = SelfEmployment(None, AccountingPeriod(LocalDate.parse("2017-03-01"), LocalDate.parse("2017-03-03")), AccountingType.CASH, Some(LocalDate.now.minusDays(1)))
       assertValidationErrorWithCode(input,
         "/accountingPeriod/start", ErrorCode.DATE_NOT_IN_THE_PAST)
     }
@@ -123,8 +123,7 @@ class SelfEmploymentSpec extends JsonSpec {
 
       assertValidationErrorsWithMessage[SelfEmployment](Json.parse(json),
         Map("/accountingPeriod" -> "error.path.missing",
-            "/accountingType" -> "error.path.missing",
-            "/commencementDate" -> "error.path.missing"))
+            "/accountingType" -> "error.path.missing"))
     }
 
     "return a error when providing an empty accountingPeriod body" in {


### PR DESCRIPTION
This was previousy implemented in MTDSA-679, however, since then the commencementDate
field was removed as it is now post-MVP.

- Make the commencementDate field optional.
- Modify Income.json so that the 'amount' is now correctly shown as
a required field.