### PR TITLE
[MTDSA-922] Conditionally allow filing-only agents.

### DIFF
--- a/app/uk/gov/hmrc/selfassessmentapi/resources/BanksAnnualSummaryResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/BanksAnnualSummaryResource.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.selfassessmentapi.resources
 
-import play.api.Logger
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc._
 import uk.gov.hmrc.domain.Nino
@@ -30,7 +29,6 @@ import scala.concurrent.Future
 object BanksAnnualSummaryResource extends BaseResource {
   private lazy val featureSwitch = FeatureSwitchAction(SourceType.Banks, "annual")
   private val annualSummaryService = BanksAnnualSummaryService
-  override val logger: Logger = Logger(BanksAnnualSummaryResource.getClass)
 
   def updateAnnualSummary(nino: Nino, id: SourceId, taxYear: TaxYear): Action[JsValue] = featureSwitch.asyncJsonFeatureSwitch { implicit request =>
     withAuth(nino) {

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/BanksAnnualSummaryResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/BanksAnnualSummaryResource.scala
@@ -33,7 +33,7 @@ object BanksAnnualSummaryResource extends BaseResource {
   override val logger: Logger = Logger(BanksAnnualSummaryResource.getClass)
 
   def updateAnnualSummary(nino: Nino, id: SourceId, taxYear: TaxYear): Action[JsValue] = featureSwitch.asyncJsonFeatureSwitch { implicit request =>
-    authorise(nino) {
+    withAuth(nino) {
       validate[BankAnnualSummary, Boolean](request.body) {
         annualSummaryService.updateAnnualSummary(nino, id, taxYear, _)
       } match {
@@ -47,7 +47,7 @@ object BanksAnnualSummaryResource extends BaseResource {
   }
 
   def retrieveAnnualSummary(nino: Nino, id: SourceId, taxYear: TaxYear): Action[AnyContent] = featureSwitch.asyncFeatureSwitch { implicit headers =>
-    authorise(nino) {
+    withAuth(nino) {
       annualSummaryService.retrieveAnnualSummary(nino, id, taxYear).map {
         case Some(summary) => Ok(Json.toJson(summary))
         case None => NotFound

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/BanksResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/BanksResource.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.selfassessmentapi.resources
 
-import play.api.Logger
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.domain.Nino
@@ -30,7 +29,6 @@ import scala.concurrent.Future
 object BanksResource extends BaseResource {
   private lazy val seFeatureSwitch = FeatureSwitchAction(SourceType.Banks)
   private val service = BanksService
-  override val logger: Logger = Logger(BanksResource.getClass)
 
   def create(nino: Nino): Action[JsValue] = seFeatureSwitch.asyncJsonFeatureSwitch { implicit request =>
     withAuth(nino) {

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/BanksResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/BanksResource.scala
@@ -33,7 +33,7 @@ object BanksResource extends BaseResource {
   override val logger: Logger = Logger(BanksResource.getClass)
 
   def create(nino: Nino): Action[JsValue] = seFeatureSwitch.asyncJsonFeatureSwitch { implicit request =>
-    authorise(nino) {
+    withAuth(nino) {
       validate[Bank, Option[SourceId]](request.body) { bank =>
         service.create(nino, bank)
       } match {
@@ -47,7 +47,7 @@ object BanksResource extends BaseResource {
   }
 
   def update(nino: Nino, id: SourceId): Action[JsValue] = seFeatureSwitch.asyncJsonFeatureSwitch { implicit request =>
-    authorise(nino) {
+    withAuth(nino) {
       validate[Bank, Boolean](request.body) { bank =>
         service.update(nino, bank, id)
       } match {
@@ -61,7 +61,7 @@ object BanksResource extends BaseResource {
   }
 
   def retrieve(nino: Nino, id: SourceId): Action[AnyContent] = seFeatureSwitch.asyncFeatureSwitch { implicit headers =>
-    authorise(nino) {
+    withAuth(nino) {
       service.retrieve(nino, id) map {
         case Some(bank) => Ok(Json.toJson(bank))
         case None => NotFound
@@ -70,7 +70,7 @@ object BanksResource extends BaseResource {
   }
 
   def retrieveAll(nino: Nino): Action[AnyContent] = seFeatureSwitch.asyncFeatureSwitch { implicit headers =>
-    authorise(nino) {
+    withAuth(nino) {
       service.retrieveAll(nino) map { seq =>
         Ok(Json.toJson(seq))
       }

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/BaseResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/BaseResource.scala
@@ -18,63 +18,34 @@ package uk.gov.hmrc.selfassessmentapi.resources
 
 import play.api.Logger
 import play.api.mvc.{RequestHeader, Result}
-import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.play.microservice.controller.BaseController
-import uk.gov.hmrc.selfassessmentapi.config.MicroserviceAuthConnector
 import uk.gov.hmrc.selfassessmentapi.connectors.BusinessDetailsConnector
-import uk.gov.hmrc.selfassessmentapi.controllers.definition.HttpMethod
-import uk.gov.hmrc.selfassessmentapi.models.Errors.Error
-import uk.gov.hmrc.selfassessmentapi.models.MtdId
+import uk.gov.hmrc.selfassessmentapi.services.AuthenticatorService
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-trait BaseResource extends BaseController with AuthorisedFunctions {
-  override def authConnector: AuthConnector = MicroserviceAuthConnector
+trait BaseResource extends BaseController {
   private val businessConnector = BusinessDetailsConnector
+  private val authService = AuthenticatorService
 
-  val logger: Logger
+  val logger: Logger = Logger(this.getClass)
 
   def withAuth(nino: Nino)(f: => Future[Result])
               (implicit hc: HeaderCarrier, reqHeader: RequestHeader): Future[Result] =
     businessConnector.get(nino).flatMap { response =>
       response.status match {
-        case 200 => authorise(response.mtdId)(f)
-        case 400 | 404 => Future.successful(Unauthorized)
+        case 200 => {
+          logger.debug(s"NINO to MTD reference lookup successful. Status Code ${response.status}.")
+          authService.authorise(response.mtdId)(f)
+        }
+        case 400 | 404 => {
+          logger.debug(s"NINO to MTD reference lookup failed. Status Code ${response.status}")
+          Future.successful(Unauthorized)
+        }
         case _ => Future.successful(unhandledResponse(response.status, logger))
       }
     }
-
-  private def authorise(mtdId: Option[MtdId])(f: => Future[Result])
-                       (implicit hc: HeaderCarrier, reqHeader: RequestHeader): Future[Result] =
-    mtdId match {
-      case Some(id) => authoriseAsClient(id)(f)
-      case None => Future.successful(Unauthorized)
-    }
-
-  private def authoriseAsClient(mtdId: MtdId)(f: => Future[Result])
-                               (implicit hc: HeaderCarrier, requestHeader: RequestHeader): Future[Result] =
-    authorised(
-      Enrolment("HMRC-MTD-IT")
-        .withIdentifier("MTDITID", mtdId.mtdId)
-        .withDelegatedAuthRule("mtd-it-auth")) {
-      f
-    } recoverWith authoriseAsFOA(f) recoverWith unauthorised
-
-  private def authoriseAsFOA(f: => Future[Result])
-                            (implicit hc: HeaderCarrier, reqHeader: RequestHeader): PartialFunction[Throwable, Future[Result]] = {
-    case _: InsufficientEnrolments => authorised(
-      Enrolment("HMRC-AS-AGENT")) {
-      if (reqHeader.method == "GET") Future.successful(Unauthorized) else f
-    }
-  }
-
-  private val unauthorised: PartialFunction[Throwable, Future[Status]] = {
-    case e: AuthorisationException => {
-      logger.debug(s"Client authorisation failed. Exception: [$e]")
-      Future.successful(Unauthorized)
-    }
-  }
 }

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/DividendsAnnualSummaryResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/DividendsAnnualSummaryResource.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.selfassessmentapi.resources
 
-import play.api.Logger
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.domain.Nino
@@ -31,7 +30,6 @@ object DividendsAnnualSummaryResource extends BaseResource {
 
   private lazy val featureSwitch = FeatureSwitchAction(SourceType.Dividends, "annual")
   private val service = DividendsAnnualSummaryService
-  override val logger: Logger = Logger(DividendsAnnualSummaryResource.getClass)
 
   def updateAnnualSummary(nino: Nino, taxYear: TaxYear): Action[JsValue] = featureSwitch.asyncJsonFeatureSwitch { implicit request =>
     withAuth(nino) {

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/DividendsAnnualSummaryResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/DividendsAnnualSummaryResource.scala
@@ -34,7 +34,7 @@ object DividendsAnnualSummaryResource extends BaseResource {
   override val logger: Logger = Logger(DividendsAnnualSummaryResource.getClass)
 
   def updateAnnualSummary(nino: Nino, taxYear: TaxYear): Action[JsValue] = featureSwitch.asyncJsonFeatureSwitch { implicit request =>
-    authorise(nino) {
+    withAuth(nino) {
       validate[Dividends, Boolean](request.body) { dividends =>
         service.updateAnnualSummary(nino, taxYear, dividends)
       } match {
@@ -47,7 +47,7 @@ object DividendsAnnualSummaryResource extends BaseResource {
   }
 
   def retrieveAnnualSummary(nino: Nino, taxYear: TaxYear): Action[AnyContent] = featureSwitch.asyncFeatureSwitch { implicit headers =>
-    authorise(nino) {
+    withAuth(nino) {
       service.retrieveAnnualSummary(nino, taxYear).map {
         case Some(summary) => Ok(Json.toJson(summary))
         case None => NotFound

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/FeatureSwitchAction.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/FeatureSwitchAction.scala
@@ -33,22 +33,12 @@ class FeatureSwitchAction(source: SourceType, summary: String) extends ActionBui
     block(request)
   }
 
-  def asyncEmptyFeatureSwitch(block: Request[Unit] => Future[Result]): Action[Unit] = {
-    if (isFeatureEnabled) async(BodyParsers.parse.empty)(block)
-    else async(BodyParsers.parse.empty)(_ => notFound)
-  }
-
   def asyncJsonFeatureSwitch(block: Request[JsValue] => Future[Result]): Action[JsValue] = {
 
     val emptyJsonParser: BodyParser[JsValue] = BodyParser { _ => Accumulator.done(Right(JsNull)) }
 
     if (isFeatureEnabled) async(BodyParsers.parse.json)(block)
     else async[JsValue](emptyJsonParser)(_ => notFound)
-  }
-
-  def asyncFeatureSwitch(block: => Future[Result]): Action[AnyContent] = {
-    if (isFeatureEnabled) async(block)
-    else async(notFound)
   }
 
   def asyncFeatureSwitch(block: RequestHeader => Future[Result]): Action[AnyContent] = {

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/PropertiesAnnualSummaryResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/PropertiesAnnualSummaryResource.scala
@@ -34,7 +34,7 @@ object PropertiesAnnualSummaryResource extends BaseResource {
   override val logger: Logger = Logger(PropertiesAnnualSummaryResource.getClass)
 
   def updateAnnualSummary(nino: Nino, propertyId: PropertyType, taxYear: TaxYear): Action[JsValue] = featureSwitch.asyncJsonFeatureSwitch { implicit request =>
-    authorise(nino) {
+    withAuth(nino) {
       validateProperty(propertyId, request.body, service.updateAnnualSummary(nino, taxYear, _)) match {
         case Left(errorResult) => Future.successful(handleValidationErrors(errorResult))
         case Right(result) => result.map {
@@ -46,7 +46,7 @@ object PropertiesAnnualSummaryResource extends BaseResource {
   }
 
   def retrieveAnnualSummary(nino: Nino, propertyId: PropertyType, taxYear: TaxYear): Action[AnyContent] = featureSwitch.asyncFeatureSwitch { implicit headers =>
-    authorise(nino) {
+    withAuth(nino) {
       service.retrieveAnnualSummary(nino, propertyId, taxYear).map {
         case Some(summary @ OtherPropertiesAnnualSummary(_, _)) => Ok(Json.toJson(summary))
         case Some(summary @ FHLPropertiesAnnualSummary(_, _)) => Ok(Json.toJson(summary))

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/PropertiesAnnualSummaryResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/PropertiesAnnualSummaryResource.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.selfassessmentapi.resources
 
-import play.api.Logger
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.domain.Nino
@@ -31,7 +30,6 @@ import scala.concurrent.Future
 object PropertiesAnnualSummaryResource extends BaseResource {
   private lazy val featureSwitch = FeatureSwitchAction(SourceType.Properties, "annual")
   private val service = PropertiesAnnualSummaryService
-  override val logger: Logger = Logger(PropertiesAnnualSummaryResource.getClass)
 
   def updateAnnualSummary(nino: Nino, propertyId: PropertyType, taxYear: TaxYear): Action[JsValue] = featureSwitch.asyncJsonFeatureSwitch { implicit request =>
     withAuth(nino) {

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/PropertiesObligationsResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/PropertiesObligationsResource.scala
@@ -28,7 +28,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 object PropertiesObligationsResource extends BaseResource {
   private val featureSwitch = FeatureSwitchAction(SourceType.Properties, "obligations")
   private val propertiesService = PropertiesObligationsService
-  override val logger: Logger = Logger(PropertiesObligationsResource.getClass)
 
   def retrieveObligations(nino: Nino): Action[AnyContent] = featureSwitch.asyncFeatureSwitch { implicit headers =>
     withAuth(nino) {

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/PropertiesObligationsResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/PropertiesObligationsResource.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.selfassessmentapi.resources
 
 import play.api.Logger
 import play.api.libs.json.Json
-import play.api.mvc.Action
+import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.selfassessmentapi.models.SourceType
 import uk.gov.hmrc.selfassessmentapi.services.PropertiesObligationsService
@@ -30,9 +30,9 @@ object PropertiesObligationsResource extends BaseResource {
   private val propertiesService = PropertiesObligationsService
   override val logger: Logger = Logger(PropertiesObligationsResource.getClass)
 
-  def retrieveObligations(nino: Nino): Action[Unit] = featureSwitch.asyncEmptyFeatureSwitch { implicit request =>
-    authorise(nino) {
-      propertiesService.retrieveObligations(nino, request.headers.get(GovTestScenarioHeader)) map {
+  def retrieveObligations(nino: Nino): Action[AnyContent] = featureSwitch.asyncFeatureSwitch { implicit headers =>
+    withAuth(nino) {
+      propertiesService.retrieveObligations(nino, headers.headers.get(GovTestScenarioHeader)) map {
         case Some(obligations) => Ok(Json.toJson(obligations))
         case None => NotFound
       }

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/PropertiesPeriodResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/PropertiesPeriodResource.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.selfassessmentapi.resources
 
-import play.api.Logger
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{Action, AnyContent, Request}
 import uk.gov.hmrc.domain.Nino
@@ -32,7 +31,6 @@ import scala.concurrent.Future
 object PropertiesPeriodResource extends BaseResource {
 
   lazy val featureSwitch = FeatureSwitchAction(SourceType.Properties, "periods")
-  override val logger: Logger = Logger(PropertiesPeriodResource.getClass)
 
   def createPeriod(nino: Nino, id: PropertyType): Action[JsValue] = featureSwitch.asyncJsonFeatureSwitch { implicit request =>
     withAuth(nino) {

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/PropertiesPeriodResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/PropertiesPeriodResource.scala
@@ -35,7 +35,7 @@ object PropertiesPeriodResource extends BaseResource {
   override val logger: Logger = Logger(PropertiesPeriodResource.getClass)
 
   def createPeriod(nino: Nino, id: PropertyType): Action[JsValue] = featureSwitch.asyncJsonFeatureSwitch { implicit request =>
-    authorise(nino) {
+    withAuth(nino) {
       validateCreateRequest(id, nino, request) match {
         case Left(errorResult) => Future.successful(handleValidationErrors(errorResult))
         case Right(result) => result.map {
@@ -52,7 +52,7 @@ object PropertiesPeriodResource extends BaseResource {
   }
 
   def updatePeriod(nino: Nino, id: PropertyType, periodId: PeriodId): Action[JsValue] = featureSwitch.asyncJsonFeatureSwitch { implicit request =>
-    authorise(nino) {
+    withAuth(nino) {
       validateUpdateRequest(id, nino, periodId, request) match {
         case Left(errorResult) => Future.successful(handleValidationErrors(errorResult))
         case Right(result) => result.map {
@@ -64,7 +64,7 @@ object PropertiesPeriodResource extends BaseResource {
   }
 
   def retrievePeriod(nino: Nino, id: PropertyType, periodId: PeriodId): Action[AnyContent] = featureSwitch.asyncFeatureSwitch { implicit headers =>
-    authorise(nino) {
+    withAuth(nino) {
       id match {
         case PropertyType.OTHER => OtherPropertiesPeriodService.retrievePeriod(nino, periodId).map {
           case Some(period) => Ok(Json.toJson(period))
@@ -79,7 +79,7 @@ object PropertiesPeriodResource extends BaseResource {
   }
 
   def retrievePeriods(nino: Nino, id: PropertyType): Action[AnyContent] = featureSwitch.asyncFeatureSwitch { implicit headers =>
-    authorise(nino) {
+    withAuth(nino) {
       id match {
         case PropertyType.OTHER => OtherPropertiesPeriodService.retrieveAllPeriods(nino).map {
           case Some(period) => Ok(Json.toJson(period))

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/PropertiesResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/PropertiesResource.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.selfassessmentapi.resources
 
-import play.api.Logger
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.domain.Nino
@@ -30,7 +29,6 @@ import scala.concurrent.Future
 object PropertiesResource extends BaseResource {
 
   lazy val featureSwitch: FeatureSwitchAction = FeatureSwitchAction(SourceType.Properties)
-  override val logger: Logger = Logger(PropertiesResource.getClass)
 
   private val service = PropertiesService()
 

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/PropertiesResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/PropertiesResource.scala
@@ -35,7 +35,7 @@ object PropertiesResource extends BaseResource {
   private val service = PropertiesService()
 
   def create(nino: Nino): Action[JsValue] = featureSwitch.asyncJsonFeatureSwitch { implicit request =>
-    authorise(nino) {
+    withAuth(nino) {
       validate[properties.Properties, Either[Error, Boolean]](request.body) {
         service.create(nino, _)
       } match {
@@ -52,7 +52,7 @@ object PropertiesResource extends BaseResource {
   }
 
   def retrieve(nino: Nino): Action[AnyContent] = featureSwitch.asyncFeatureSwitch { implicit headers =>
-    authorise(nino) {
+    withAuth(nino) {
       service.retrieve(nino).map {
         case Some(properties) => Ok(Json.toJson(properties))
         case None => NotFound

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentAnnualSummaryResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentAnnualSummaryResource.scala
@@ -35,7 +35,7 @@ object SelfEmploymentAnnualSummaryResource extends BaseResource {
   val logger = Logger(SelfEmploymentAnnualSummaryResource.getClass)
 
   def updateAnnualSummary(nino: Nino, id: SourceId, taxYear: TaxYear): Action[JsValue] = annualSummaryFeatureSwitch.asyncJsonFeatureSwitch { implicit request =>
-    authorise(nino) {
+    withAuth(nino) {
       validate[SelfEmploymentAnnualSummary, SelfEmploymentAnnualSummaryResponse](request.body) { summary =>
         connector.update(nino, id, taxYear, des.SelfEmploymentAnnualSummary.from(summary))
       } match {
@@ -54,7 +54,7 @@ object SelfEmploymentAnnualSummaryResource extends BaseResource {
 
   // TODO: DES spec for this method is currently unavailable. This method should be updated once it is available.
   def retrieveAnnualSummary(nino: Nino, id: SourceId, taxYear: TaxYear): Action[AnyContent] = annualSummaryFeatureSwitch.asyncFeatureSwitch { implicit request =>
-    authorise(nino) {
+    withAuth(nino) {
       connector.get(nino, id, taxYear).map { response =>
         response.status match {
           case 200 => response.annualSummary.map(x => Ok(Json.toJson(x))).getOrElse(NotFound)

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentAnnualSummaryResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentAnnualSummaryResource.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.selfassessmentapi.resources
 
-import play.api.Logger
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc._
 import uk.gov.hmrc.domain.Nino
@@ -32,7 +31,6 @@ import scala.concurrent.Future
 object SelfEmploymentAnnualSummaryResource extends BaseResource {
   private lazy val annualSummaryFeatureSwitch = FeatureSwitchAction(SourceType.SelfEmployments, "annual")
   private val connector = SelfEmploymentAnnualSummaryConnector
-  val logger = Logger(SelfEmploymentAnnualSummaryResource.getClass)
 
   def updateAnnualSummary(nino: Nino, id: SourceId, taxYear: TaxYear): Action[JsValue] = annualSummaryFeatureSwitch.asyncJsonFeatureSwitch { implicit request =>
     withAuth(nino) {

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentObligationsResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentObligationsResource.scala
@@ -32,7 +32,7 @@ object SelfEmploymentObligationsResource extends BaseResource {
   val logger = Logger(SelfEmploymentObligationsResource.getClass)
 
   def retrieveObligations(nino: Nino, id: SourceId): Action[AnyContent] = featureSwitch.asyncFeatureSwitch { implicit headers =>
-    authorise(nino) {
+    withAuth(nino) {
       connector.get(nino, id).map { response =>
         response.status match {
           case 200 =>

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentObligationsResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentObligationsResource.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.selfassessmentapi.resources
 
-import play.api.Logger
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.domain.Nino
@@ -29,7 +28,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 object SelfEmploymentObligationsResource extends BaseResource {
   private lazy val featureSwitch = FeatureSwitchAction(SourceType.SelfEmployments, "obligations")
   private val connector = SelfEmploymentObligationsConnector
-  val logger = Logger(SelfEmploymentObligationsResource.getClass)
 
   def retrieveObligations(nino: Nino, id: SourceId): Action[AnyContent] = featureSwitch.asyncFeatureSwitch { implicit headers =>
     withAuth(nino) {

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentPeriodResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentPeriodResource.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.selfassessmentapi.resources
 
-import play.api.Logger
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.domain.Nino
@@ -33,7 +32,6 @@ import scala.concurrent.Future
 object SelfEmploymentPeriodResource extends BaseResource {
   private lazy val featureSwitch = FeatureSwitchAction(SourceType.SelfEmployments, "periods")
   private val connector = SelfEmploymentPeriodConnector
-  val logger = Logger(SelfEmploymentPeriodResource.getClass)
 
   def createPeriod(nino: Nino, sourceId: SourceId): Action[JsValue] = featureSwitch.asyncJsonFeatureSwitch { implicit request =>
     withAuth(nino) {

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentPeriodResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentPeriodResource.scala
@@ -36,7 +36,7 @@ object SelfEmploymentPeriodResource extends BaseResource {
   val logger = Logger(SelfEmploymentPeriodResource.getClass)
 
   def createPeriod(nino: Nino, sourceId: SourceId): Action[JsValue] = featureSwitch.asyncJsonFeatureSwitch { implicit request =>
-    authorise(nino) {
+    withAuth(nino) {
       validate[SelfEmploymentPeriod, SelfEmploymentPeriodResponse](request.body) { period =>
         connector.create(nino, sourceId, des.SelfEmploymentPeriod.from(period))
       } match {
@@ -56,7 +56,7 @@ object SelfEmploymentPeriodResource extends BaseResource {
 
   // TODO: DES spec for this method is currently unavailable. This method should be updated once it is available.
   def updatePeriod(nino: Nino, id: SourceId, periodId: PeriodId): Action[JsValue] = featureSwitch.asyncJsonFeatureSwitch { implicit request =>
-    authorise(nino) {
+    withAuth(nino) {
       validate[SelfEmploymentPeriodUpdate, SelfEmploymentPeriodResponse](request.body) { period =>
         connector.update(nino, id, periodId, Financials.from(period.incomes, period.expenses))
       } match {
@@ -75,7 +75,7 @@ object SelfEmploymentPeriodResource extends BaseResource {
 
   // TODO: DES spec for this method is currently unavailable. This method should be updated once it is available.
   def retrievePeriod(nino: Nino, id: SourceId, periodId: PeriodId): Action[AnyContent] = featureSwitch.asyncFeatureSwitch { implicit request =>
-    authorise(nino) {
+    withAuth(nino) {
       connector.get(nino, id, periodId).map { response =>
         response.status match {
           case 200 => response.period.map(x => Ok(Json.toJson(x))).getOrElse(NotFound)
@@ -89,7 +89,7 @@ object SelfEmploymentPeriodResource extends BaseResource {
 
   // TODO: DES spec for this method is currently unavailable. This method should be updated once it is available.
   def retrievePeriods(nino: Nino, id: SourceId): Action[AnyContent] = featureSwitch.asyncFeatureSwitch { implicit request =>
-    authorise(nino) {
+    withAuth(nino) {
       connector.getAll(nino, id).map { response =>
         response.status match {
           case 200 => Ok(Json.toJson(response.allPeriods))

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentsResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentsResource.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.selfassessmentapi.resources
 
-import play.api.Logger
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.domain.Nino
@@ -32,7 +31,6 @@ import scala.concurrent.Future
 object SelfEmploymentsResource extends BaseResource {
   private lazy val seFeatureSwitch = FeatureSwitchAction(SourceType.SelfEmployments)
   private val connector = SelfEmploymentConnector
-  val logger = Logger(SelfEmploymentsResource.getClass)
 
   def create(nino: Nino): Action[JsValue] = seFeatureSwitch.asyncJsonFeatureSwitch { implicit request =>
     withAuth(nino) {

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentsResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentsResource.scala
@@ -22,7 +22,7 @@ import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.selfassessmentapi.connectors.SelfEmploymentConnector
 import uk.gov.hmrc.selfassessmentapi.models.Errors.Error
-import uk.gov.hmrc.selfassessmentapi.models.{Errors, _}
+import uk.gov.hmrc.selfassessmentapi.models._
 import uk.gov.hmrc.selfassessmentapi.models.selfemployment.{SelfEmployment, SelfEmploymentUpdate}
 import uk.gov.hmrc.selfassessmentapi.resources.wrappers.SelfEmploymentResponse
 
@@ -35,7 +35,7 @@ object SelfEmploymentsResource extends BaseResource {
   val logger = Logger(SelfEmploymentsResource.getClass)
 
   def create(nino: Nino): Action[JsValue] = seFeatureSwitch.asyncJsonFeatureSwitch { implicit request =>
-    authorise(nino) {
+    withAuth(nino) {
       validate[SelfEmployment, SelfEmploymentResponse](request.body) { selfEmployment =>
         connector.create(nino, des.Business.from(selfEmployment))
       } match {
@@ -55,7 +55,7 @@ object SelfEmploymentsResource extends BaseResource {
 
   // TODO: DES spec for this method is currently unavailable. This method should be updated once it is available.
   def update(nino: Nino, id: SourceId): Action[JsValue] = seFeatureSwitch.asyncJsonFeatureSwitch { implicit request =>
-    authorise(nino) {
+    withAuth(nino) {
       validate[SelfEmploymentUpdate, SelfEmploymentResponse](request.body) { selfEmployment =>
         connector.update(nino, des.SelfEmploymentUpdate.from(selfEmployment), id)
       } match {
@@ -73,7 +73,7 @@ object SelfEmploymentsResource extends BaseResource {
   }
 
   def retrieve(nino: Nino, id: SourceId): Action[AnyContent] = seFeatureSwitch.asyncFeatureSwitch { implicit request =>
-    authorise(nino) {
+    withAuth(nino) {
       connector.get(nino).map { response =>
         response.status match {
           case 200 => response.selfEmployment(id).map(x => Ok(Json.toJson(x))).getOrElse(NotFound)
@@ -86,7 +86,7 @@ object SelfEmploymentsResource extends BaseResource {
   }
 
   def retrieveAll(nino: Nino): Action[AnyContent] = seFeatureSwitch.asyncFeatureSwitch { implicit request =>
-    authorise(nino) {
+    withAuth(nino) {
       connector.get(nino).map { response =>
         response.status match {
           case 200 => Ok(Json.toJson(response.listSelfEmployment))

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/TaxCalculationResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/TaxCalculationResource.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.selfassessmentapi.resources
 
-import play.api.Logger
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.domain.Nino
@@ -33,7 +32,6 @@ object TaxCalculationResource extends BaseResource {
 
   private lazy val featureSwitch = FeatureSwitchAction(SourceType.Calculation)
   private val connector = TaxCalculationConnector
-  val logger = Logger(TaxCalculationResource.getClass)
 
   private val cannedEtaResponse =
     s"""

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/TaxCalculationResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/TaxCalculationResource.scala
@@ -43,7 +43,7 @@ object TaxCalculationResource extends BaseResource {
      """.stripMargin
 
   def requestCalculation(nino: Nino): Action[JsValue] = featureSwitch.asyncJsonFeatureSwitch { implicit request =>
-    authorise(nino) {
+    withAuth(nino) {
       validate[CalculationRequest, TaxCalculationResponse](request.body) { req =>
         connector.requestCalculation(nino, req.taxYear)
       } match {
@@ -62,7 +62,7 @@ object TaxCalculationResource extends BaseResource {
   }
 
   def retrieveCalculation(nino: Nino, calcId: SourceId): Action[AnyContent] = featureSwitch.asyncFeatureSwitch { implicit request =>
-    authorise(nino) {
+    withAuth(nino) {
       connector.retrieveCalculation(nino, calcId).map { response =>
         response.status match {
           case 200 => Ok(Json.toJson(response.calculation))

--- a/app/uk/gov/hmrc/selfassessmentapi/services/AuthenticatorService.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/services/AuthenticatorService.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.selfassessmentapi.services
+
+import play.api.Logger
+import play.api.mvc.Results._
+import play.api.mvc.{RequestHeader, Result}
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.play.http.HeaderCarrier
+import uk.gov.hmrc.selfassessmentapi.config.MicroserviceAuthConnector
+import uk.gov.hmrc.selfassessmentapi.models.MtdId
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+object AuthenticatorService extends AuthorisedFunctions {
+  override def authConnector: AuthConnector = MicroserviceAuthConnector
+
+  private val logger = Logger(AuthenticatorService.getClass)
+
+  def authorise(mtdId: Option[MtdId])(f: => Future[Result])
+               (implicit hc: HeaderCarrier, reqHeader: RequestHeader): Future[Result] =
+    mtdId match {
+      case Some(id) => authoriseAsClient(id)(f)
+      case None => Future.successful(Unauthorized)
+    }
+
+  private def authoriseAsClient(mtdId: MtdId)(f: => Future[Result])
+                               (implicit hc: HeaderCarrier, requestHeader: RequestHeader): Future[Result] =
+    authorised(
+      Enrolment("HMRC-MTD-IT")
+        .withIdentifier("MTDITID", mtdId.mtdId)
+        .withDelegatedAuthRule("mtd-it-auth")) {
+      logger.debug("Client authorisation succeeded as fully-authorised individual.")
+      f
+    } recoverWith authoriseAsFOA(f) recoverWith unauthorised
+
+  private def authoriseAsFOA(f: => Future[Result])
+                            (implicit hc: HeaderCarrier, reqHeader: RequestHeader): PartialFunction[Throwable, Future[Result]] = {
+    case _: InsufficientEnrolments => authorised(
+      Enrolment("HMRC-AS-AGENT")) {
+      if (reqHeader.method == "GET") {
+        logger.debug("Client authorisation failed. Attempt to GET as a filing-only agent.")
+        Future.successful(Unauthorized)
+      } else {
+        logger.debug("Client authorisation succeeded as filing-only agent.")
+        f
+      }
+    }
+  }
+
+  private def unauthorised(implicit requestHeader: RequestHeader): PartialFunction[Throwable, Future[Status]] = {
+    case e: AuthorisationException => {
+      logger.debug(s"Client authorisation failed. Exception: [$e]")
+      Future.successful(Unauthorized)
+    }
+  }
+}

--- a/func/uk/gov/hmrc/selfassessmentapi/AcceptHeaderSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/AcceptHeaderSpec.scala
@@ -9,6 +9,7 @@ class AcceptHeaderSpec extends BaseFunctionalSpec {
   "if the valid content type header is sent in the request, they" should {
     "receive 200" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.noneFor(nino)
         .when()
@@ -20,6 +21,7 @@ class AcceptHeaderSpec extends BaseFunctionalSpec {
   "if the valid content type header is missing in the request, they" should {
     "receive 406" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeReturnedFor(nino)
         .when()

--- a/func/uk/gov/hmrc/selfassessmentapi/AcceptHeaderSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/AcceptHeaderSpec.scala
@@ -9,7 +9,7 @@ class AcceptHeaderSpec extends BaseFunctionalSpec {
   "if the valid content type header is sent in the request, they" should {
     "receive 200" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.noneFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments").withAcceptHeader()
@@ -20,7 +20,7 @@ class AcceptHeaderSpec extends BaseFunctionalSpec {
   "if the valid content type header is missing in the request, they" should {
     "receive 406" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeReturnedFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments").withoutAcceptHeader()

--- a/func/uk/gov/hmrc/selfassessmentapi/AgentAuthorisationSimulationSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/AgentAuthorisationSimulationSpec.scala
@@ -11,7 +11,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
     // START GET
     "receive a HTTP 403 Unauthorized when they attempt to retrieve all self-employments" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/self-employments")
         .withHeaders(GovTestScenarioHeader, "AGENT_NOT_AUTHORIZED")
@@ -22,7 +23,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
 
     "receive a HTTP 403 Unauthorized when they attempt to retrieve a specific self-employment" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/self-employments/abc")
         .withHeaders(GovTestScenarioHeader, "AGENT_NOT_AUTHORIZED")
@@ -33,7 +35,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
 
     "receive a HTTP 403 Unauthorized when they attempt to retrieve a specific self-employment obligations" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/self-employments/abc/obligations")
         .withHeaders(GovTestScenarioHeader, "AGENT_NOT_AUTHORIZED")
@@ -44,7 +47,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
 
     "receive a HTTP 403 Unauthorized when they attempt to retrieve a specific self-employment annual summary" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/self-employments/abc/$taxYear")
         .withHeaders(GovTestScenarioHeader, "AGENT_NOT_AUTHORIZED")
@@ -55,7 +59,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
 
     "receive a HTTP 403 Unauthorized when they attempt to retrieve all specific self-employment periods" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/self-employments/abc/periods")
         .withHeaders(GovTestScenarioHeader, "AGENT_NOT_AUTHORIZED")
@@ -66,7 +71,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
 
     "receive a HTTP 403 Unauthorized when they attempt to retrieve a specific self-employment period" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/self-employments/abc/periods/def")
         .withHeaders(GovTestScenarioHeader, "AGENT_NOT_AUTHORIZED")
@@ -79,7 +85,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
 
     "receive an unmodified HTTP 400 Bad Request when they attempt to create a self-employment using an invalid json" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.SelfEmployment(accountingType = "NONSENSE")).to(s"/ni/$nino/self-employments")
         .withHeaders(GovTestScenarioHeader, "AGENT_NOT_AUTHORIZED")
@@ -90,7 +97,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
 
     "receive a modified HTTP 400 Bad Request when they attempt to create a periodic summary using an invalid identifier" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.SelfEmployment.period()).to(s"/ni/$nino/self-employments/invalid-id/periods")
         .withHeaders(GovTestScenarioHeader, "AGENT_NOT_AUTHORIZED")
@@ -100,7 +108,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
 
     "receive a modified HTTP 400 Bad Request when they attempt to update a periodic summary with an invalid identifier" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.periodWillNotBeUpdatedFor(nino)
         .when()
         .put(Jsons.SelfEmployment.period()).at(s"/ni/$nino/self-employments/abc/periods/def")
@@ -111,7 +120,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
 
     "receive an unmodified HTTP 400 Bad Request when they attempt to create a periodic summary with an invalid json" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeCreatedFor(nino)
         .des().selfEmployment.willBeReturnedFor(nino)
         .when()
@@ -128,7 +138,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
 
     "receive an unmodified HTTP 400 Bad Request when they attempt to update a periodic summary with an invalid json" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeCreatedFor(nino)
         .des().selfEmployment.willBeReturnedFor(nino)
         .des().selfEmployment.periodWillBeCreatedFor(nino)
@@ -151,7 +162,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
 
     "receive a modified HTTP 400 Bad Request when they attempt to update an annual summary with an invalid identifier" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.annualSummaryWillNotBeUpdatedFor(nino)
         .when()
         .put(Jsons.SelfEmployment.annualSummary()).at(s"/ni/$nino/self-employments/abc/$taxYear")
@@ -162,7 +174,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
 
     "receive a modified HTTP 400 Bad Request when they attempt to create more than one self-employment source" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.tooManySourcesFor(nino)
         .when()
         .post(Jsons.SelfEmployment()).to(s"/ni/$nino/self-employments")
@@ -176,7 +189,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
   "An unauthorized agent (i.e. a FOA) interacting with properties" should {
     "receive a HTTP 403 Unauthorized when they attempt to retrieve property information" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/uk-properties")
         .withHeaders(GovTestScenarioHeader, "AGENT_NOT_AUTHORIZED")
@@ -187,7 +201,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
 
     "receive a HTTP 403 Unauthorized when they attempt to retrieve property obligations" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/uk-properties/obligations")
         .withHeaders(GovTestScenarioHeader, "AGENT_NOT_AUTHORIZED")
@@ -198,7 +213,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
 
     "receive a HTTP 403 Unauthorized when they attempt to retrieve property annual summaries" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/uk-properties/furnished-holiday-lettings/$taxYear")
         .withHeaders(GovTestScenarioHeader, "AGENT_NOT_AUTHORIZED")
@@ -215,7 +231,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
 
     "receive a HTTP 403 Unauthorized when they attempt to retrieve all property periods" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/uk-properties/furnished-holiday-lettings/periods")
         .withHeaders(GovTestScenarioHeader, "AGENT_NOT_AUTHORIZED")
@@ -232,7 +249,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
 
     "receive a HTTP 403 Unauthorized when they attempt to retrieve specific 'other' property periods" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.Properties()).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -252,7 +270,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
 
     "receive a HTTP 403 Unauthorized when they attempt to retrieve specific 'fhl' property periods" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.Properties()).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -272,7 +291,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
 
     "receive a HTTP 400 when they attempt to create a property with an invalid json" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(JsString("NONSENSE")).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -281,7 +301,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
 
     "receive an unmodified HTTP 400 when they attempt to update an annual summary with an invalid json" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.Properties()).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -297,7 +318,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
 
     "receive an unmodified HTTP 400 when they attempt to create a periodic summary with an invalid json" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.Properties()).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -313,7 +335,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
 
     "receive a modified HTTP 400 when they attempt to update a periodic summary with an invalid identifier" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .put(Jsons.Properties.otherPeriod())
         .at(s"/ni/$nino/uk-properties/other/periods/invalid-id")
@@ -324,7 +347,8 @@ class AgentAuthorisationSimulationSpec extends BaseFunctionalSpec {
 
     "receive a modified HTTP 400 when they attempt to create more than one uk property business" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.Properties())
         .to(s"/ni/$nino/uk-properties")

--- a/func/uk/gov/hmrc/selfassessmentapi/AgentSubscriptionSimulationSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/AgentSubscriptionSimulationSpec.scala
@@ -9,7 +9,7 @@ class AgentSubscriptionSimulationSpec extends BaseFunctionalSpec {
   "Request for self-employments with Gov-Test-Scenario = AGENT_NOT_SUBSCRIBED" should {
     "return HTTP 403 with error code informing Agent should be subscribed to Agent Services" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/self-employments")
         .withHeaders(GovTestScenarioHeader, "AGENT_NOT_SUBSCRIBED")
@@ -22,7 +22,7 @@ class AgentSubscriptionSimulationSpec extends BaseFunctionalSpec {
   "Request for dividends with Gov-Test-Scenario = AGENT_NOT_SUBSCRIBED" should {
     "return HTTP 403 with error code informing Agent should be subscribed to Agent Services" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(s"/ni/$nino/dividends/$taxYear")
         .withHeaders(GovTestScenarioHeader, "AGENT_NOT_SUBSCRIBED")

--- a/func/uk/gov/hmrc/selfassessmentapi/AgentSubscriptionSimulationSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/AgentSubscriptionSimulationSpec.scala
@@ -9,6 +9,7 @@ class AgentSubscriptionSimulationSpec extends BaseFunctionalSpec {
   "Request for self-employments with Gov-Test-Scenario = AGENT_NOT_SUBSCRIBED" should {
     "return HTTP 403 with error code informing Agent should be subscribed to Agent Services" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/self-employments")
@@ -22,6 +23,7 @@ class AgentSubscriptionSimulationSpec extends BaseFunctionalSpec {
   "Request for dividends with Gov-Test-Scenario = AGENT_NOT_SUBSCRIBED" should {
     "return HTTP 403 with error code informing Agent should be subscribed to Agent Services" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(s"/ni/$nino/dividends/$taxYear")

--- a/func/uk/gov/hmrc/selfassessmentapi/AuthorisationSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/AuthorisationSpec.scala
@@ -1,12 +1,14 @@
 package uk.gov.hmrc.selfassessmentapi
 
+import uk.gov.hmrc.selfassessmentapi.resources.Jsons
 import uk.gov.hmrc.support.BaseFunctionalSpec
 
 class AuthorisationSpec extends BaseFunctionalSpec {
 
-  "if the user is not authorised for the resource they" should {
+  "if the user is not authorised they" should {
     "receive 401" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsNotAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/self-employments")
@@ -16,14 +18,51 @@ class AuthorisationSpec extends BaseFunctionalSpec {
     }
   }
 
-  "if the user is authorised for the resource they" should {
+  "if the user is authorised for the resource as a client or fully-authorised agent they" should {
     "receive 200" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/self-employments")
         .thenAssertThat()
         .statusIs(200)
+        .contentTypeIsJson()
+    }
+  }
+
+  "if the user is authorised as a filing-only agent they" should {
+    "be able to make POST requests" in {
+      given()
+        .userIsSubscribedToMtdFor(nino)
+        .userIsPartiallyAuthorisedForTheResource(nino)
+        .des().selfEmployment.willBeCreatedFor(nino)
+        .when()
+        .post(Jsons.SelfEmployment()).to(s"/ni/$nino/self-employments")
+        .thenAssertThat()
+        .statusIs(201)
+        .contentTypeIsJson()
+    }
+
+    "be able to make PUT requests" in {
+      given()
+        .userIsSubscribedToMtdFor(nino)
+        .userIsPartiallyAuthorisedForTheResource(nino)
+        .des().selfEmployment.willBeUpdatedFor(nino)
+        .when()
+        .put(Jsons.SelfEmployment.update()).at(s"/ni/$nino/self-employments/abc")
+        .thenAssertThat()
+        .statusIs(204)
+    }
+
+    "be forbidden from making GET requests" in {
+      given()
+        .userIsSubscribedToMtdFor(nino)
+        .userIsPartiallyAuthorisedForTheResource(nino)
+        .when()
+        .get(s"/ni/$nino/self-employments/abc")
+        .thenAssertThat()
+        .statusIs(401)
         .contentTypeIsJson()
     }
   }

--- a/func/uk/gov/hmrc/selfassessmentapi/ClientSubscriptionSimulationSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/ClientSubscriptionSimulationSpec.scala
@@ -9,6 +9,7 @@ class ClientSubscriptionSimulationSpec extends BaseFunctionalSpec {
   "Request for self-employments with Gov-Test-Scenario = CLIENT_NOT_SUBSCRIBED" should {
     "return HTTP 403 with error code informing client should be subscribed to MTD" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/self-employments")
@@ -22,6 +23,7 @@ class ClientSubscriptionSimulationSpec extends BaseFunctionalSpec {
   "Request for dividends with Gov-Test-Scenario = CLIENT_NOT_SUBSCRIBED" should {
     "return HTTP 403 with error code informing client should be subscribed to MTD" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(s"/ni/$nino/dividends/$taxYear")

--- a/func/uk/gov/hmrc/selfassessmentapi/ClientSubscriptionSimulationSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/ClientSubscriptionSimulationSpec.scala
@@ -9,7 +9,7 @@ class ClientSubscriptionSimulationSpec extends BaseFunctionalSpec {
   "Request for self-employments with Gov-Test-Scenario = CLIENT_NOT_SUBSCRIBED" should {
     "return HTTP 403 with error code informing client should be subscribed to MTD" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/self-employments")
         .withHeaders(GovTestScenarioHeader, "CLIENT_NOT_SUBSCRIBED")
@@ -22,7 +22,7 @@ class ClientSubscriptionSimulationSpec extends BaseFunctionalSpec {
   "Request for dividends with Gov-Test-Scenario = CLIENT_NOT_SUBSCRIBED" should {
     "return HTTP 403 with error code informing client should be subscribed to MTD" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(s"/ni/$nino/dividends/$taxYear")
         .withHeaders(GovTestScenarioHeader, "CLIENT_NOT_SUBSCRIBED")

--- a/func/uk/gov/hmrc/selfassessmentapi/EmptyResponseFilterSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/EmptyResponseFilterSpec.scala
@@ -9,7 +9,8 @@ class EmptyResponseFilterSpec extends BaseFunctionalSpec {
   "Empty response filter should" should {
     "be applied when returning an HTTP 201 e.g.: creating a self-employment" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeCreatedFor(nino)
         .when()
         .post(Jsons.SelfEmployment())
@@ -21,7 +22,8 @@ class EmptyResponseFilterSpec extends BaseFunctionalSpec {
 
     "be applied when returning an HTTP 409 e.g.: attempting to create a properties business more than once" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.Properties())
         .to(s"/ni/$nino/uk-properties")

--- a/func/uk/gov/hmrc/selfassessmentapi/MicroserviceAuditFilterSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/MicroserviceAuditFilterSpec.scala
@@ -13,7 +13,8 @@ class MicroserviceAuditFilterSpec extends BaseFunctionalSpec {
   "Audit filter" should {
     "be applied when a POST request is made" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeCreatedFor(nino)
         .when()
         .post(Jsons.SelfEmployment()).to(s"/ni/$nino/self-employments")

--- a/func/uk/gov/hmrc/selfassessmentapi/MicroserviceMonitoringFilterSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/MicroserviceMonitoringFilterSpec.scala
@@ -8,7 +8,7 @@ class MicroserviceMonitoringFilterSpec extends BaseFunctionalSpec {
   "Monitoring filter" should {
     "be applied when requests are made" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeCreatedFor(nino)
         .des().selfEmployment.willBeReturnedFor(nino)
         .when()

--- a/func/uk/gov/hmrc/selfassessmentapi/TestScenarioHeaderSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/TestScenarioHeaderSpec.scala
@@ -7,6 +7,7 @@ class TestScenarioHeaderSpec extends BaseFunctionalSpec {
   "Request for self-employments with no Gov-Test-Scenario" should {
     "return HTTP 200" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeReturnedFor(nino)
         .when()
@@ -19,6 +20,7 @@ class TestScenarioHeaderSpec extends BaseFunctionalSpec {
   "Request for self-employments with invalid Gov-Test-Scenario" should {
     "return HTTP 200" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeReturnedFor(nino)
         .when()
@@ -32,6 +34,7 @@ class TestScenarioHeaderSpec extends BaseFunctionalSpec {
   "Request for dividends with no Gov-Test-Scenario" should {
     "return HTTP 200" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeReturnedFor(nino)
         .when()
@@ -44,6 +47,7 @@ class TestScenarioHeaderSpec extends BaseFunctionalSpec {
   "Request for dividends with invalid Gov-Test-Scenario" should {
     "return HTTP 200" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeReturnedFor(nino)
         .when()

--- a/func/uk/gov/hmrc/selfassessmentapi/TestScenarioHeaderSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/TestScenarioHeaderSpec.scala
@@ -7,7 +7,7 @@ class TestScenarioHeaderSpec extends BaseFunctionalSpec {
   "Request for self-employments with no Gov-Test-Scenario" should {
     "return HTTP 200" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeReturnedFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments")
@@ -19,7 +19,7 @@ class TestScenarioHeaderSpec extends BaseFunctionalSpec {
   "Request for self-employments with invalid Gov-Test-Scenario" should {
     "return HTTP 200" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeReturnedFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments")
@@ -32,7 +32,7 @@ class TestScenarioHeaderSpec extends BaseFunctionalSpec {
   "Request for dividends with no Gov-Test-Scenario" should {
     "return HTTP 200" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeReturnedFor(nino)
         .when()
         .get(s"/ni/$nino/dividends/$taxYear")
@@ -44,7 +44,7 @@ class TestScenarioHeaderSpec extends BaseFunctionalSpec {
   "Request for dividends with invalid Gov-Test-Scenario" should {
     "return HTTP 200" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeReturnedFor(nino)
         .when()
         .get(s"/ni/$nino/dividends/$taxYear")

--- a/func/uk/gov/hmrc/selfassessmentapi/featureswitch/AgentSimulationFeatureSwitchDisabledSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/featureswitch/AgentSimulationFeatureSwitchDisabledSpec.scala
@@ -13,6 +13,7 @@ class AgentSimulationFeatureSwitchDisabledSpec extends BaseFunctionalSpec {
   "Agent simulation filters" should {
     "not be applied if feature is switched off" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeReturnedFor(nino)
         .when()

--- a/func/uk/gov/hmrc/selfassessmentapi/featureswitch/AgentSimulationFeatureSwitchDisabledSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/featureswitch/AgentSimulationFeatureSwitchDisabledSpec.scala
@@ -13,7 +13,7 @@ class AgentSimulationFeatureSwitchDisabledSpec extends BaseFunctionalSpec {
   "Agent simulation filters" should {
     "not be applied if feature is switched off" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeReturnedFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments")

--- a/func/uk/gov/hmrc/selfassessmentapi/featureswitch/SelfEmploymentAnnualSummaryFeatureSwitchSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/featureswitch/SelfEmploymentAnnualSummaryFeatureSwitchSpec.scala
@@ -19,6 +19,7 @@ class SelfEmploymentAnnualSummaryFeatureSwitchSpec extends BaseFunctionalSpec {
     "not be visible if feature Switched Off" in {
 
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeReturnedFor(nino)
         .when()

--- a/func/uk/gov/hmrc/selfassessmentapi/featureswitch/SelfEmploymentAnnualSummaryFeatureSwitchSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/featureswitch/SelfEmploymentAnnualSummaryFeatureSwitchSpec.scala
@@ -19,7 +19,7 @@ class SelfEmploymentAnnualSummaryFeatureSwitchSpec extends BaseFunctionalSpec {
     "not be visible if feature Switched Off" in {
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeReturnedFor(nino)
         .when()
         .put(Json.toJson(SelfEmploymentAnnualSummary(None, None))).at(s"/ni/$nino/self-employments/abc/$taxYear")

--- a/func/uk/gov/hmrc/selfassessmentapi/featureswitch/SelfEmploymentFeatureSwitchSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/featureswitch/SelfEmploymentFeatureSwitchSpec.scala
@@ -20,7 +20,7 @@ class SelfEmploymentFeatureSwitchSpec extends BaseFunctionalSpec {
   "self-employments" should {
     "not be visible if feature Switched Off" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/${SourceType.SelfEmployments.toString}")
         .thenAssertThat()

--- a/func/uk/gov/hmrc/selfassessmentapi/featureswitch/SelfEmploymentFeatureSwitchSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/featureswitch/SelfEmploymentFeatureSwitchSpec.scala
@@ -20,6 +20,7 @@ class SelfEmploymentFeatureSwitchSpec extends BaseFunctionalSpec {
   "self-employments" should {
     "not be visible if feature Switched Off" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/${SourceType.SelfEmployments.toString}")

--- a/func/uk/gov/hmrc/selfassessmentapi/featureswitch/SelfEmploymentPeriodicSummaryFeatureSwitchSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/featureswitch/SelfEmploymentPeriodicSummaryFeatureSwitchSpec.scala
@@ -20,7 +20,8 @@ class SelfEmploymentPeriodicSummaryFeatureSwitchSpec extends BaseFunctionalSpec 
   "self-employments" should {
     "not be visible if feature Switched Off" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeCreatedFor(nino)
         .when()
         .post(Jsons.SelfEmployment()).to(s"/ni/$nino/self-employments")

--- a/func/uk/gov/hmrc/selfassessmentapi/resources/BanksAnnualSummaryResourceSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/resources/BanksAnnualSummaryResourceSpec.scala
@@ -6,7 +6,8 @@ class BanksAnnualSummaryResourceSpec extends BaseFunctionalSpec {
   "updateAnnualSummary" should {
     "return code 204 when successfully updating a bank annual summary" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.Banks()).to(s"/ni/$nino/savings-accounts")
         .thenAssertThat()
@@ -28,7 +29,8 @@ class BanksAnnualSummaryResourceSpec extends BaseFunctionalSpec {
 
     "return code 400 when attempting to update a bank annual summary with invalid JSON" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.Banks()).to(s"/ni/$nino/savings-accounts")
         .thenAssertThat()
@@ -44,7 +46,8 @@ class BanksAnnualSummaryResourceSpec extends BaseFunctionalSpec {
 
     "return code 404 when attempting to update a bank annual summary for a non-existent bank" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .put(Jsons.Banks.annualSummary(Some(50.123), Some(12.552))).at(s"/ni/$nino/savings-accounts/sillyid/$taxYear")
         .thenAssertThat()
@@ -55,7 +58,8 @@ class BanksAnnualSummaryResourceSpec extends BaseFunctionalSpec {
   "retrieveAnnualSummary" should {
     "return code 200 for an annual summary that exists" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.Banks()).to(s"/ni/$nino/savings-accounts")
         .thenAssertThat()
@@ -73,7 +77,8 @@ class BanksAnnualSummaryResourceSpec extends BaseFunctionalSpec {
 
     "return code 200 with empty json when retrieving a banks annual summary that does not exist" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.Banks()).to(s"/ni/$nino/savings-accounts")
         .thenAssertThat()
@@ -87,7 +92,8 @@ class BanksAnnualSummaryResourceSpec extends BaseFunctionalSpec {
 
     "return code 404 when attempting to access an annual summary for a banks source that does not exist" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/savings-accounts/sillyid/$taxYear")
         .thenAssertThat()

--- a/func/uk/gov/hmrc/selfassessmentapi/resources/BanksResourceSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/resources/BanksResourceSpec.scala
@@ -8,7 +8,8 @@ class BanksResourceSpec extends BaseFunctionalSpec {
 
     "return code 201 containing a location header when creating a bank interest source" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.Banks()).to(s"/ni/$nino/savings-accounts")
         .thenAssertThat()
@@ -23,7 +24,8 @@ class BanksResourceSpec extends BaseFunctionalSpec {
 
     "return code 400 when attempting to create a bank interest source with invalid information" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.Banks("A waaaayyyyyyyyyyyyyyyyyyyyyy to looooong account name")).to(s"/ni/$nino/savings-accounts")
         .thenAssertThat()
@@ -36,7 +38,8 @@ class BanksResourceSpec extends BaseFunctionalSpec {
 
     "return code 204 when updating bank interest source information" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.Banks()).to(s"/ni/$nino/savings-accounts")
         .thenAssertThat()
@@ -54,7 +57,8 @@ class BanksResourceSpec extends BaseFunctionalSpec {
 
     "return code 400 when updating a bank interest source with invalid information" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.Banks()).to(s"/ni/$nino/savings-accounts")
         .thenAssertThat()
@@ -68,7 +72,8 @@ class BanksResourceSpec extends BaseFunctionalSpec {
 
     "return code 404 when updating a a bank interest source that does not exist" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .put(Jsons.Banks()).at(s"/ni/$nino/savings-accounts/2435234523")
         .thenAssertThat()
@@ -79,7 +84,8 @@ class BanksResourceSpec extends BaseFunctionalSpec {
   "retrieving a bank interest source" should {
     "return code 404 when accessing a a bank interest source which doesn't exists" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/savings-accounts/23452345235")
         .thenAssertThat()

--- a/func/uk/gov/hmrc/selfassessmentapi/resources/DesJsons.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/resources/DesJsons.scala
@@ -81,22 +81,22 @@ object DesJsons {
        """.stripMargin
     }
 
-    def emptySelfEmployment(nino: Nino): String = {
+    def emptySelfEmployment(nino: Nino, mtdId: String): String = {
       s"""
          |{
          |   "safeId": "XE00001234567890",
          |   "nino": "$nino",
-         |   "mtdbsa": "123456789012345",
+         |   "mtdbsa": "$mtdId",
          |   "propertyIncome": false
          |}
        """.stripMargin
     }
 
-    def createResponse(id: String): String = {
+    def createResponse(id: String, mtdId: String): String = {
       s"""
          |{
          |  "safeId": "XA0001234567890",
-         |  "mtditId": "mdtitId001",
+         |  "mtdsba": "$mtdId",
          |  "incomeSources": [
          |    {
          |      "incomeSourceId": "$id"

--- a/func/uk/gov/hmrc/selfassessmentapi/resources/DividendsAnnualSummaryResourceSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/resources/DividendsAnnualSummaryResourceSpec.scala
@@ -7,7 +7,8 @@ class DividendsAnnualSummaryResourceSpec extends BaseFunctionalSpec {
   "update annual summary" should {
     "return code 204 when updating dividends" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .put(Jsons.Dividends(500)).at(s"/ni/$nino/dividends/$taxYear")
         .thenAssertThat()
@@ -39,7 +40,8 @@ class DividendsAnnualSummaryResourceSpec extends BaseFunctionalSpec {
 
     "return code 400 when updating dividends with an invalid value" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .put(Jsons.Dividends(-50.123)).at(s"/ni/$nino/dividends/$taxYear")
         .thenAssertThat()
@@ -51,7 +53,8 @@ class DividendsAnnualSummaryResourceSpec extends BaseFunctionalSpec {
   "retrieve annual summary" should {
     "return code 200 with empty json when retrieving a dividends annual summary that does not exist" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/dividends/$taxYear")
         .thenAssertThat()

--- a/func/uk/gov/hmrc/selfassessmentapi/resources/PropertiesAnnualSummaryResourceSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/resources/PropertiesAnnualSummaryResourceSpec.scala
@@ -19,7 +19,8 @@ class PropertiesAnnualSummaryResourceSpec extends BaseFunctionalSpec {
         balancingCharge = 350.34)
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -48,7 +49,8 @@ class PropertiesAnnualSummaryResourceSpec extends BaseFunctionalSpec {
         "INVALID_MONETARY_AMOUNT" -> "/adjustments/privateUseAdjustment")
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -73,7 +75,8 @@ class PropertiesAnnualSummaryResourceSpec extends BaseFunctionalSpec {
         balancingCharge = 350.34)
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .put(annualSummaries).at(s"/ni/$nino/uk-properties/other/$taxYear")
         .thenAssertThat()
@@ -94,7 +97,8 @@ class PropertiesAnnualSummaryResourceSpec extends BaseFunctionalSpec {
         balancingCharge = 350.34)
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -123,7 +127,8 @@ class PropertiesAnnualSummaryResourceSpec extends BaseFunctionalSpec {
         balancingCharge = 350.34)
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -144,7 +149,8 @@ class PropertiesAnnualSummaryResourceSpec extends BaseFunctionalSpec {
       val property = Jsons.Properties()
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -159,7 +165,8 @@ class PropertiesAnnualSummaryResourceSpec extends BaseFunctionalSpec {
 
     "return code 404 when retrieving annual summaries for a properties business that does not exist" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/uk-properties/other/$taxYear")
         .thenAssertThat()
@@ -170,7 +177,8 @@ class PropertiesAnnualSummaryResourceSpec extends BaseFunctionalSpec {
       val property = Jsons.Properties()
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()

--- a/func/uk/gov/hmrc/selfassessmentapi/resources/PropertiesObligationsResourceSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/resources/PropertiesObligationsResourceSpec.scala
@@ -6,7 +6,8 @@ class PropertiesObligationsResourceSpec extends BaseFunctionalSpec {
   "retrieveObligations" should {
     "return code 200 containing a set of canned obligations, all of which have not been met" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.Properties()).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -20,7 +21,8 @@ class PropertiesObligationsResourceSpec extends BaseFunctionalSpec {
 
     "return code 200 containing a set of canned obligations of which only the first has been met" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.Properties()).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -34,7 +36,8 @@ class PropertiesObligationsResourceSpec extends BaseFunctionalSpec {
 
     "return code 200 containing a set of canned obligations, all of which have been met" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.Properties()).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -48,7 +51,8 @@ class PropertiesObligationsResourceSpec extends BaseFunctionalSpec {
 
     "return code 404 when attempting to retrieve obligations for a properties business that does not exist" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/uk-properties/obligations")
         .thenAssertThat()

--- a/func/uk/gov/hmrc/selfassessmentapi/resources/PropertiesPeriodicSummarySpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/resources/PropertiesPeriodicSummarySpec.scala
@@ -19,7 +19,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
         otherCost = 50.22)
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -48,7 +49,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
         otherCost = 50.22)
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -73,7 +75,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
         "INVALID_MONETARY_AMOUNT" -> "/expenses/financialCosts/amount")
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -101,7 +104,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
         "INVALID_MONETARY_AMOUNT" -> "/incomes/premiumsOfLeaseGrant/amount")
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -120,7 +124,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
       val periodTwo = Jsons.Properties.fhlPeriod(fromDate = Some("2017-04-06"), toDate = Some("2018-04-02"))
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -144,7 +149,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
       val periodTwo = Jsons.Properties.otherPeriod(fromDate = Some("2017-04-06"), toDate = Some("2018-04-02"))
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -167,7 +173,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
       val periodTwo = Jsons.Properties.fhlPeriod(fromDate = Some("2017-04-06"), toDate = Some("2018-04-01"))
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -189,7 +196,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
       val periodTwo = Jsons.Properties.otherPeriod(fromDate = Some("2017-04-06"), toDate = Some("2018-04-01"))
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -221,7 +229,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
         ("2017-04-08", "2017-04-09"))
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -257,7 +266,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
         ("2017-04-08", "2017-04-09"))
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -283,7 +293,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
       val property = Jsons.Properties()
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -300,7 +311,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
       val property = Jsons.Properties()
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -315,7 +327,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
 
     "return code 404 for an FHL property business that does not exist" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/uk-properties/furnished-holiday-lettings/periods")
         .thenAssertThat()
@@ -324,7 +337,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
 
     "return code 404 for an Other property business that does not exist" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/uk-properties/other/periods")
         .thenAssertThat()
@@ -340,7 +354,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
         toDate = Some("2018-04-05"))
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -364,7 +379,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
         toDate = Some("2018-04-05"))
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -385,7 +401,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
       val property = Jsons.Properties()
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -400,7 +417,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
       val property = Jsons.Properties()
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -429,7 +447,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
         otherCost = 50.12)
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -470,7 +489,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
         otherCost = 50.12)
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -507,7 +527,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
         "INVALID_MONETARY_AMOUNT" -> "/expenses/financialCosts/amount")
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -542,7 +563,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
         "INVALID_MONETARY_AMOUNT" -> "/incomes/premiumsOfLeaseGrant/amount")
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -566,7 +588,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
         toDate = Some("2018-04-05"))
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -584,7 +607,8 @@ class PropertiesPeriodicSummarySpec extends BaseFunctionalSpec {
         toDate = Some("2018-04-05"))
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(property).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()

--- a/func/uk/gov/hmrc/selfassessmentapi/resources/PropertiesResourceSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/resources/PropertiesResourceSpec.scala
@@ -8,7 +8,8 @@ class PropertiesResourceSpec extends BaseFunctionalSpec {
   "creating a property business" should {
     "return code 201 containing a location header when creating a uk property business" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.Properties()).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -23,7 +24,8 @@ class PropertiesResourceSpec extends BaseFunctionalSpec {
 
     "return code 409 when attempting to create the same property business more than once" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.Properties()).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -37,7 +39,8 @@ class PropertiesResourceSpec extends BaseFunctionalSpec {
 
     "return code 400 when attempting to create a property business with invalid information" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(JsString("OOPS")).to(s"/ni/$nino/uk-properties")
         .thenAssertThat()
@@ -48,7 +51,8 @@ class PropertiesResourceSpec extends BaseFunctionalSpec {
   "retrieving a property business" should {
     "return code 404 when accessing a property business which doesn't exists" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/uk-properties")
         .thenAssertThat()

--- a/func/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentAnnualSummaryResourceSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentAnnualSummaryResourceSpec.scala
@@ -7,7 +7,8 @@ class SelfEmploymentAnnualSummaryResourceSpec extends BaseFunctionalSpec {
   "updateAnnualSummary" should {
     "return code 204 when updating an annual summary for a valid self-employment source" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.annualSummaryWillBeUpdatedFor(nino)
         .when()
         .put(Jsons.SelfEmployment.annualSummary()).at(s"/ni/$nino/self-employments/abc/$taxYear")
@@ -17,7 +18,8 @@ class SelfEmploymentAnnualSummaryResourceSpec extends BaseFunctionalSpec {
 
     "return code 404 when updating an annual summary for an invalid self-employment source" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.annualSummaryNotFoundFor(nino)
         .when()
         .put(Jsons.SelfEmployment.annualSummary()).at(s"/ni/$nino/self-employments/sillysource/$taxYear")
@@ -37,7 +39,8 @@ class SelfEmploymentAnnualSummaryResourceSpec extends BaseFunctionalSpec {
         ("INVALID_MONETARY_AMOUNT", "/allowances/capitalAllowanceMainPool"))
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .put(annualSummaries).at(s"/ni/$nino/self-employments/abc/$taxYear")
         .thenAssertThat()
@@ -48,7 +51,8 @@ class SelfEmploymentAnnualSummaryResourceSpec extends BaseFunctionalSpec {
 
     "return code 400 when provided with an invalid Originator-Id header" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.invalidOriginatorIdFor(nino)
         .when()
         .put(Jsons.SelfEmployment.annualSummary()).at(s"/ni/$nino/self-employments/abc/$taxYear")
@@ -60,7 +64,8 @@ class SelfEmploymentAnnualSummaryResourceSpec extends BaseFunctionalSpec {
 
     "return code 400 when provided with an invalid payload" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().payloadFailsValidationFor(nino)
         .when()
         .put(Jsons.SelfEmployment.annualSummary()).at(s"/ni/$nino/self-employments/abc/$taxYear")
@@ -72,7 +77,8 @@ class SelfEmploymentAnnualSummaryResourceSpec extends BaseFunctionalSpec {
 
     "return code 500 when DES is experiencing problems" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().serverErrorFor(nino)
         .when()
         .put(Jsons.SelfEmployment.annualSummary()).at(s"/ni/$nino/self-employments/abc/$taxYear")
@@ -84,7 +90,8 @@ class SelfEmploymentAnnualSummaryResourceSpec extends BaseFunctionalSpec {
 
     "return code 500 when a dependent system is not responding" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().serviceUnavailableFor(nino)
         .when()
         .put(Jsons.SelfEmployment.annualSummary()).at(s"/ni/$nino/self-employments/abc/$taxYear")
@@ -96,7 +103,8 @@ class SelfEmploymentAnnualSummaryResourceSpec extends BaseFunctionalSpec {
 
     "return code 500 when we receive a status code from DES that we do not handle" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().isATeapotFor(nino)
         .when()
         .put(Jsons.SelfEmployment.update()).at(s"/ni/$nino/self-employments/$taxYear")
@@ -128,7 +136,8 @@ class SelfEmploymentAnnualSummaryResourceSpec extends BaseFunctionalSpec {
       ).toString
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.annualSummaryWillBeReturnedFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments/abc/$taxYear")
@@ -141,7 +150,8 @@ class SelfEmploymentAnnualSummaryResourceSpec extends BaseFunctionalSpec {
     "return code 200 containing an empty object when retrieving a non-existent annual summary" in {
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.noAnnualSummaryFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments/abc/$taxYear")
@@ -153,7 +163,8 @@ class SelfEmploymentAnnualSummaryResourceSpec extends BaseFunctionalSpec {
 
     "return code 404 when retrieving an annual summary for a non-existent self-employment" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.annualSummaryWillNotBeReturnedFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments/abc/$taxYear")
@@ -163,7 +174,8 @@ class SelfEmploymentAnnualSummaryResourceSpec extends BaseFunctionalSpec {
 
     "return code 400 when retrieving annual summary for a non MTD year" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/$nino/self-employments/abc/2015-16")
         .thenAssertThat()
@@ -173,7 +185,8 @@ class SelfEmploymentAnnualSummaryResourceSpec extends BaseFunctionalSpec {
 
     "return code 500 when we receive a status code from DES that we do not handle" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().isATeapotFor(nino)
         .when()
         .put(Jsons.SelfEmployment.update()).at(s"/ni/$nino/self-employments/abc/$taxYear")

--- a/func/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentObligationsResourceSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentObligationsResourceSpec.scala
@@ -7,7 +7,8 @@ class SelfEmploymentObligationsResourceSpec extends BaseFunctionalSpec {
 
     "return code 200 with a set of obligations" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().obligations.returnObligationsFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments/abc/obligations")
@@ -18,7 +19,8 @@ class SelfEmploymentObligationsResourceSpec extends BaseFunctionalSpec {
 
     "forward the GovTestScenario header to DES" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().obligations.receivesObligationsTestHeader(nino, "ALL_MET")
         .when()
         .get(s"/ni/$nino/self-employments/abc/obligations").withHeaders(GovTestScenarioHeader, "ALL_MET")
@@ -29,7 +31,8 @@ class SelfEmploymentObligationsResourceSpec extends BaseFunctionalSpec {
 
     "return code 404 when self employment id does not exist" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().obligations.obligationNotFoundFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments/abc/obligations")
@@ -39,7 +42,8 @@ class SelfEmploymentObligationsResourceSpec extends BaseFunctionalSpec {
 
     "return code 400 when nino is invalid" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().invalidNinoFor(nino)
         .when()
         .get("/ni/abcd1234/self-employments/abc/obligations")

--- a/func/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentPeriodResourceSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentPeriodResourceSpec.scala
@@ -14,7 +14,8 @@ class SelfEmploymentPeriodResourceSpec extends BaseFunctionalSpec {
         toDate = Some("2017-07-04"))
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeCreatedFor(nino)
         .des().selfEmployment.periodWillBeCreatedFor(nino)
         .when()
@@ -40,7 +41,8 @@ class SelfEmploymentPeriodResourceSpec extends BaseFunctionalSpec {
       val expectedBody = Jsons.Errors.invalidRequest(("INVALID_PERIOD", ""))
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeCreatedFor(nino)
         .when()
         .post(Jsons.SelfEmployment()).to(s"/ni/$nino/self-employments")
@@ -58,7 +60,8 @@ class SelfEmploymentPeriodResourceSpec extends BaseFunctionalSpec {
       val overlappingPeriod = Jsons.SelfEmployment.period(fromDate = Some("2017-08-04"), toDate = Some("2017-09-04"))
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeCreatedFor(nino)
         .des().selfEmployment.invalidPeriodFor(nino)
         .when()
@@ -78,7 +81,8 @@ class SelfEmploymentPeriodResourceSpec extends BaseFunctionalSpec {
         toDate = Some("2017-07-04"))
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.periodWillBeNotBeCreatedFor(nino)
         .when()
         .post(period).to(s"/ni/$nino/self-employments/abc/periods")
@@ -92,7 +96,8 @@ class SelfEmploymentPeriodResourceSpec extends BaseFunctionalSpec {
         toDate = Some("2017-07-04"))
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().serverErrorFor(nino)
         .when()
         .post(period).to(s"/ni/$nino/self-employments/abc/periods")
@@ -107,7 +112,8 @@ class SelfEmploymentPeriodResourceSpec extends BaseFunctionalSpec {
         toDate = Some("2017-07-04"))
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().serviceUnavailableFor(nino)
         .when()
         .post(period).to(s"/ni/$nino/self-employments/abc/periods")
@@ -118,7 +124,8 @@ class SelfEmploymentPeriodResourceSpec extends BaseFunctionalSpec {
 
     "return code 500 when we receive a status code from DES that we do not handle" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().isATeapotFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments/abc/periods")
@@ -136,7 +143,8 @@ class SelfEmploymentPeriodResourceSpec extends BaseFunctionalSpec {
         cisPaymentsToSubcontractors = (100.25, 55.25))
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.periodWillBeUpdatedFor(nino)
         .when()
         .put(updatePeriod).at(s"/ni/$nino/self-employments/abc/periods/def")
@@ -154,7 +162,8 @@ class SelfEmploymentPeriodResourceSpec extends BaseFunctionalSpec {
         cisPaymentsToSubcontractors = (100.25, 50.25))
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.periodWillNotBeUpdatedFor(nino)
         .when()
         .put(Json.toJson(period)).at(s"/ni/$nino/self-employments/abc/periods/def")
@@ -172,7 +181,8 @@ class SelfEmploymentPeriodResourceSpec extends BaseFunctionalSpec {
         cisPaymentsToSubcontractors = (100.25, 50.25))
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().isATeapotFor(nino)
         .when()
         .put(Json.toJson(period)).at(s"/ni/$nino/self-employments/abc/periods/def")
@@ -204,7 +214,8 @@ class SelfEmploymentPeriodResourceSpec extends BaseFunctionalSpec {
         otherExpenses = (200, 200))
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.periodWillBeReturnedFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments/abc/periods/def")
@@ -218,7 +229,8 @@ class SelfEmploymentPeriodResourceSpec extends BaseFunctionalSpec {
     "return code 404 when retrieving a period that does not exist" in {
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.noPeriodFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments/abc/periods/def")
@@ -228,7 +240,8 @@ class SelfEmploymentPeriodResourceSpec extends BaseFunctionalSpec {
 
     "return code 500 when we receive a status code from DES that we do not handle" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().isATeapotFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments/abc/periods/def")
@@ -254,7 +267,8 @@ class SelfEmploymentPeriodResourceSpec extends BaseFunctionalSpec {
          """.stripMargin
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.periodsWillBeReturnedFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments/abc/periods")
@@ -267,7 +281,8 @@ class SelfEmploymentPeriodResourceSpec extends BaseFunctionalSpec {
 
     "return code 200 containing an empty json body when retrieving all periods where periods.size == 0" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.noPeriodsFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments/abc/periods")
@@ -278,7 +293,8 @@ class SelfEmploymentPeriodResourceSpec extends BaseFunctionalSpec {
 
     "return code 404 when retrieving all periods for a non-existent self-employment source" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.doesNotExistPeriodFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments/abc/periods")
@@ -288,7 +304,8 @@ class SelfEmploymentPeriodResourceSpec extends BaseFunctionalSpec {
 
     "return code 500 when we receive a status code from DES that we do not handle" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().isATeapotFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments/abc/periods")

--- a/func/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentsResourceSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentsResourceSpec.scala
@@ -212,6 +212,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
       val expectedSelfEmployment = Jsons.SelfEmployment(cessationDate = None, businessDescription = None)
 
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeReturnedFor(nino)
         .when()
@@ -225,6 +226,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 401 when attempting to retrieve a self-employment that fails DES nino validation" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .des().invalidNinoFor(nino)
         .when()
@@ -236,6 +238,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 404 when retrieving a self-employment resource that does not exist" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.noneFor(nino)
         .when()
@@ -246,6 +249,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 400 when retrieving a self-employment that fails nino validation" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/teapot/self-employments/invalidSourceId")
@@ -256,6 +260,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 401 when retrieving a self-employment for a nino that does not exist" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .des().ninoNotFoundFor(nino)
         .when()
@@ -266,6 +271,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 500 when DES is experiencing issues" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .des().serverErrorFor(nino)
         .when()
@@ -277,6 +283,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 500 when systems that DES is dependant on are experiencing issues" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .des().serviceUnavailableFor(nino)
         .when()
@@ -288,6 +295,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 500 when we receive a status code from DES that we do not handle" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .des().isATeapotFor(nino)
         .when()
@@ -308,6 +316,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
          """.stripMargin
 
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeReturnedFor(nino)
         .when()
@@ -321,6 +330,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 200 with an empty body when the user has no self-employment sources" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.noneFor(nino)
         .when()
@@ -332,6 +342,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 401 when attempting to retrieve self-employments that fails DES nino validation" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .des().invalidNinoFor(nino)
         .when()
@@ -343,6 +354,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 401 when attempting to retrieve self-employments for a nino that does not exist" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .des().ninoNotFoundFor(nino)
         .when()
@@ -353,6 +365,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 500 when we receive a status code from DES that we do not handle" in {
       given()
+        .userIsSubscribedToMtdFor(nino)
         .userIsFullyAuthorisedForTheResource(nino)
         .des().isATeapotFor(nino)
         .when()

--- a/func/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentsResourceSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentsResourceSpec.scala
@@ -9,7 +9,8 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
   "create" should {
     "return code 201 containing a location header when creating a valid a self-employment source of income" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeCreatedFor(nino)
         .when()
         .post(Jsons.SelfEmployment()).to(s"/ni/$nino/self-employments")
@@ -20,7 +21,8 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 400 (INVALID_REQUEST) when attempting to create a self-employment with an invalid dates in the accountingPeriod" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.SelfEmployment(accPeriodStart = "01-01-2017", accPeriodEnd = "02-01-2017")).to(s"/ni/$nino/self-employments")
         .thenAssertThat()
@@ -31,7 +33,8 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 400 (INVALID_VALUE) when attempting to create a self-employment with an invalid accounting type" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.SelfEmployment(accountingType = "INVALID_ACC_TYPE")).to(s"/ni/$nino/self-employments")
         .thenAssertThat()
@@ -42,7 +45,8 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 400 when attempting to create a self-employment that fails DES validation" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().payloadFailsValidationFor(nino)
         .when()
         .post(Jsons.SelfEmployment()).to(s"/ni/$nino/self-employments")
@@ -53,7 +57,8 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 401 when attempting to create a self-employment that fails DES nino validation" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().ninoNotFoundFor(nino)
         .when()
         .post(Jsons.SelfEmployment()).to(s"/ni/$nino/self-employments")
@@ -63,7 +68,8 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 400 when attempting to create a self-employment that fails DES duplicated trading name validaton" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.failsTradingName(nino)
         .when()
         .post(Jsons.SelfEmployment()).to(s"/ni/$nino/self-employments")
@@ -74,7 +80,8 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 500 when DES is experiencing issues" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().serverErrorFor(nino)
         .when()
         .post(Jsons.SelfEmployment()).to(s"/ni/$nino/self-employments")
@@ -85,7 +92,8 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 500 when systems that DES is dependant on are experiencing issues" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().serviceUnavailableFor(nino)
         .when()
         .post(Jsons.SelfEmployment()).to(s"/ni/$nino/self-employments")
@@ -96,7 +104,8 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 403 Unauthorized when attempting to create more than one self-employment source" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.tooManySourcesFor(nino)
         .when()
         .post(Jsons.SelfEmployment()).to(s"/ni/$nino/self-employments")
@@ -107,7 +116,8 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 500 when we receive a status code from DES that we do not handle" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().isATeapotFor(nino)
         .when()
         .post(Jsons.SelfEmployment()).to(s"/ni/$nino/self-employments")
@@ -119,7 +129,8 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
   "update" should {
     "return code 204 when successfully updating a self-employment resource" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeCreatedFor(nino)
         .des().selfEmployment.willBeUpdatedFor(nino)
         .when()
@@ -134,7 +145,8 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 404 when attempting to update a non-existent self-employment resource" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willNotBeUpdatedFor(nino)
         .when()
         .put(Jsons.SelfEmployment.update()).at(s"/ni/$nino/self-employments/invalidSourceId")
@@ -144,7 +156,8 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 400 (MANDATORY_FIELD_MISSING) when attempting to update a self-employment with an empty body" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeCreatedFor(nino)
         .when()
         .post(Jsons.SelfEmployment()).to(s"/ni/$nino/self-employments")
@@ -166,7 +179,8 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
       val updatedSelfEmployment = Jsons.SelfEmployment.update(businessDescription = "invalid")
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeCreatedFor(nino)
         .when()
         .post(Jsons.SelfEmployment()).to(s"/ni/$nino/self-employments")
@@ -183,7 +197,8 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 500 when we receive a status code from DES that we do not handle" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().isATeapotFor(nino)
         .when()
         .put(Jsons.SelfEmployment.update()).at(s"/ni/$nino/self-employments/abc")
@@ -197,7 +212,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
       val expectedSelfEmployment = Jsons.SelfEmployment(cessationDate = None, businessDescription = None)
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeReturnedFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments/abc")
@@ -210,7 +225,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 401 when attempting to retrieve a self-employment that fails DES nino validation" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().invalidNinoFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments/sourceId")
@@ -221,7 +236,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 404 when retrieving a self-employment resource that does not exist" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.noneFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments/invalidSourceId")
@@ -231,7 +246,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 400 when retrieving a self-employment that fails nino validation" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .get(s"/ni/teapot/self-employments/invalidSourceId")
         .thenAssertThat()
@@ -241,7 +256,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 401 when retrieving a self-employment for a nino that does not exist" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().ninoNotFoundFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments/invalidSourceId")
@@ -251,7 +266,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 500 when DES is experiencing issues" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().serverErrorFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments/invalidSourceId")
@@ -262,7 +277,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 500 when systems that DES is dependant on are experiencing issues" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().serviceUnavailableFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments/invalidSourceId")
@@ -273,7 +288,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 500 when we receive a status code from DES that we do not handle" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().isATeapotFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments/abc")
@@ -293,7 +308,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
          """.stripMargin
 
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.willBeReturnedFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments")
@@ -306,7 +321,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 200 with an empty body when the user has no self-employment sources" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().selfEmployment.noneFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments")
@@ -317,7 +332,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 401 when attempting to retrieve self-employments that fails DES nino validation" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().invalidNinoFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments")
@@ -328,7 +343,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 401 when attempting to retrieve self-employments for a nino that does not exist" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().ninoNotFoundFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments")
@@ -338,7 +353,7 @@ class SelfEmploymentsResourceSpec extends BaseFunctionalSpec {
 
     "return code 500 when we receive a status code from DES that we do not handle" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().isATeapotFor(nino)
         .when()
         .get(s"/ni/$nino/self-employments")

--- a/func/uk/gov/hmrc/selfassessmentapi/resources/TaxCalculationResourceSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/resources/TaxCalculationResourceSpec.scala
@@ -10,7 +10,8 @@ class TaxCalculationResourceSpec extends BaseFunctionalSpec {
 
     "return 202 containing a Location header, along with an ETA for the calculation to be ready" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().taxCalculation.isAcceptedFor(nino)
         .when()
         .post(Jsons.TaxCalculation.request()).to(s"/ni/$nino/calculations")
@@ -22,7 +23,8 @@ class TaxCalculationResourceSpec extends BaseFunctionalSpec {
 
     "return 400 when attempting to request calculation without specifying a tax year" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Json.obj()).to(s"/ni/$nino/calculations")
         .thenAssertThat()
@@ -32,7 +34,8 @@ class TaxCalculationResourceSpec extends BaseFunctionalSpec {
 
     "return 400 when attempting to request calculation with invalid tax year" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .when()
         .post(Jsons.TaxCalculation.request("2011-12")).to(s"/ni/$nino/calculations")
         .thenAssertThat()
@@ -42,7 +45,8 @@ class TaxCalculationResourceSpec extends BaseFunctionalSpec {
 
     "return code 500 when we receive a status code from DES that we do not handle" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().isATeapotFor(nino)
         .when()
         .post(Jsons.TaxCalculation.request()).to(s"/ni/$nino/calculations")
@@ -55,7 +59,8 @@ class TaxCalculationResourceSpec extends BaseFunctionalSpec {
   "retrieveCalculation" should {
     "return 200 containing a calculation" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().taxCalculation.isReadyFor(nino)
         .when()
         .get(s"/ni/$nino/calculations/abc")
@@ -66,7 +71,8 @@ class TaxCalculationResourceSpec extends BaseFunctionalSpec {
 
     "return 204 when the calculation is not ready" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().taxCalculation.isNotReadyFor(nino)
         .when()
         .get(s"/ni/$nino/calculations/abc")
@@ -76,7 +82,8 @@ class TaxCalculationResourceSpec extends BaseFunctionalSpec {
 
     "return 404 when provided with an invalid calculation ID" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().taxCalculation.invalidCalculationIdFor(nino)
         .when()
         .get(s"/ni/$nino/calculations/abc")
@@ -86,7 +93,8 @@ class TaxCalculationResourceSpec extends BaseFunctionalSpec {
 
     "return 404 when attempting to retrieve a calculation using an invalid id" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().taxCalculation.doesNotExistFor(nino)
         .when()
         .get(s"/ni/$nino/calculations/abc")
@@ -96,7 +104,8 @@ class TaxCalculationResourceSpec extends BaseFunctionalSpec {
 
     "return code 500 when we receive a status code from DES that we do not handle" in {
       given()
-        .userIsAuthorisedForTheResource(nino)
+        .userIsSubscribedToMtdFor(nino)
+        .userIsFullyAuthorisedForTheResource(nino)
         .des().isATeapotFor(nino)
         .when()
         .get(s"/ni/$nino/calculations/abc")


### PR DESCRIPTION
- Add additional auth step which checks if the client is able to act as
a filing-only agent should they not be a fully-authorised agent.
- Update tests.