### PR TITLE
[MTDSA-1030] Refactor request validation to non-blocking calls

### DIFF
--- a/app/uk/gov/hmrc/selfassessmentapi/resources/PropertiesResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/PropertiesResource.scala
@@ -25,7 +25,6 @@ import uk.gov.hmrc.selfassessmentapi.models._
 import uk.gov.hmrc.selfassessmentapi.resources.wrappers.PropertiesResponse
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
 
 object PropertiesResource extends BaseResource {
 
@@ -33,15 +32,15 @@ object PropertiesResource extends BaseResource {
 
   private val connector = PropertiesConnector
 
-  def create(nino: Nino): Action[JsValue] = FeatureSwitch.async(parse.json) { implicit request =>
-    withAuth(nino) { implicit context =>
-      validate[properties.Properties, PropertiesResponse](request.body) { props =>
-        connector.create(nino, props)
-      } match {
-        case Left(errorResult) =>
-          Future.successful(handleValidationErrors(errorResult))
-        case Right(response) =>
-          response.map { response =>
+  def create(nino: Nino): Action[JsValue] =
+    FeatureSwitch.async(parse.json) { implicit request =>
+      withAuth(nino) { implicit context =>
+        validate[properties.Properties, PropertiesResponse](request.body) { props =>
+          connector.create(nino, props)
+        } map {
+          case Left(errorResult) =>
+            handleValidationErrors(errorResult)
+          case Right(response) =>
             response.filter {
               case 200 => Created.withHeaders(LOCATION -> response.createLocationHeader(nino))
               case 403 => Conflict.withHeaders(LOCATION -> s"/self-assessment/ni/$nino/uk-properties")
@@ -49,24 +48,25 @@ object PropertiesResource extends BaseResource {
               case 404 => NotFound
               case _ => unhandledResponse(response.status, logger)
             }
-          }
-      }
-    }
-  }
-
-  def retrieve(nino: Nino): Action[AnyContent] = FeatureSwitch.async { implicit request =>
-    withAuth(nino) { implicit context =>
-      connector.retrieve(nino).map { response =>
-        response.filter {
-          case 200 => response.property match {
-            case Some(property) => Ok(Json.toJson(property))
-            case None => NotFound
-          }
-          case 404 => NotFound
-          case 400 if response.isInvalidNino => BadRequest(Json.toJson(Errors.NinoInvalid))
-          case _ => unhandledResponse(response.status, logger)
         }
       }
     }
-  }
+
+  def retrieve(nino: Nino): Action[AnyContent] =
+    FeatureSwitch.async { implicit request =>
+      withAuth(nino) { implicit context =>
+        connector.retrieve(nino).map { response =>
+          response.filter {
+            case 200 =>
+              response.property match {
+                case Some(property) => Ok(Json.toJson(property))
+                case None => NotFound
+              }
+            case 404 => NotFound
+            case 400 if response.isInvalidNino => BadRequest(Json.toJson(Errors.NinoInvalid))
+            case _ => unhandledResponse(response.status, logger)
+          }
+        }
+      }
+    }
 }

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentAnnualSummaryResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentAnnualSummaryResource.scala
@@ -26,40 +26,40 @@ import uk.gov.hmrc.selfassessmentapi.models.selfemployment.SelfEmploymentAnnualS
 import uk.gov.hmrc.selfassessmentapi.resources.wrappers.SelfEmploymentAnnualSummaryResponse
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
 
 object SelfEmploymentAnnualSummaryResource extends BaseResource {
   private lazy val FeatureSwitch = FeatureSwitchAction(SourceType.SelfEmployments, "annual")
   private val connector = SelfEmploymentAnnualSummaryConnector
 
-  def updateAnnualSummary(nino: Nino, id: SourceId, taxYear: TaxYear): Action[JsValue] = FeatureSwitch.async(parse.json) { implicit request =>
-    withAuth(nino) { implicit context =>
-      validate[SelfEmploymentAnnualSummary, SelfEmploymentAnnualSummaryResponse](request.body) { summary =>
-        connector.update(nino, id, taxYear, des.SelfEmploymentAnnualSummary.from(summary))
-      } match {
-        case Left(errorResult) => Future.successful(handleValidationErrors(errorResult))
-        case Right(result) => result.map { response =>
+  def updateAnnualSummary(nino: Nino, id: SourceId, taxYear: TaxYear): Action[JsValue] =
+    FeatureSwitch.async(parse.json) { implicit request =>
+      withAuth(nino) { implicit context =>
+        validate[SelfEmploymentAnnualSummary, SelfEmploymentAnnualSummaryResponse](request.body) { summary =>
+          connector.update(nino, id, taxYear, des.SelfEmploymentAnnualSummary.from(summary))
+        } map {
+          case Left(errorResult) => handleValidationErrors(errorResult)
+          case Right(response) =>
+            response.filter {
+              case 200 => NoContent
+              case 400 => BadRequest(Error.from(response.json))
+              case 404 => NotFound
+              case _ => unhandledResponse(response.status, logger)
+            }
+        }
+      }
+    }
+
+  // TODO: DES spec for this method is currently unavailable. This method should be updated once it is available.
+  def retrieveAnnualSummary(nino: Nino, id: SourceId, taxYear: TaxYear): Action[Unit] =
+    FeatureSwitch.async(parse.empty) { implicit request =>
+      withAuth(nino) { implicit context =>
+        connector.get(nino, id, taxYear).map { response =>
           response.filter {
-            case 200 => NoContent
-            case 400 => BadRequest(Error.from(response.json))
+            case 200 => response.annualSummary.map(x => Ok(Json.toJson(x))).getOrElse(NotFound)
             case 404 => NotFound
             case _ => unhandledResponse(response.status, logger)
           }
         }
       }
     }
-  }
-
-  // TODO: DES spec for this method is currently unavailable. This method should be updated once it is available.
-  def retrieveAnnualSummary(nino: Nino, id: SourceId, taxYear: TaxYear) = FeatureSwitch.async(parse.empty) { implicit request =>
-    withAuth(nino) { implicit context =>
-      connector.get(nino, id, taxYear).map { response =>
-        response.filter {
-          case 200 => response.annualSummary.map(x => Ok(Json.toJson(x))).getOrElse(NotFound)
-          case 404 => NotFound
-          case _ => unhandledResponse(response.status, logger)
-        }
-      }
-    }
-  }
 }

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentPeriodResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentPeriodResource.scala
@@ -35,57 +35,53 @@ object SelfEmploymentPeriodResource extends BaseResource {
   private lazy val FeatureSwitch = FeatureSwitchAction(SourceType.SelfEmployments, "periods")
   private val connector = SelfEmploymentPeriodConnector
 
-  def createPeriod(nino: Nino, sourceId: SourceId): Action[JsValue] = FeatureSwitch.async(parse.json) {
-    implicit request =>
+  def createPeriod(nino: Nino, sourceId: SourceId): Action[JsValue] =
+    FeatureSwitch.async(parse.json) { implicit request =>
       withAuth(nino) { implicit context =>
         validate[SelfEmploymentPeriod, (PeriodId, SelfEmploymentPeriodResponse)](request.body) { period =>
           connector
             .create(nino, sourceId, period)
             .map((period.createPeriodId, _))
-        } match {
-          case Left(errorResult) => Future.successful(handleValidationErrors(errorResult))
-          case Right(result) =>
-            result.map {
-              case (periodId, response) =>
-                response.filter {
-                  case 200 =>
-                    auditPeriodicCreate(nino, sourceId, response, periodId)
-                    Created.withHeaders(LOCATION -> response.createLocationHeader(nino, sourceId, periodId))
-                  case 400 if response.isInvalidBusinessId => NotFound
-                  case 400 if response.isInvalidPeriod => Forbidden(Json.toJson(Errors.businessError(Errors.InvalidPeriod)))
-                  case 400 if response.isInvalidNino => BadRequest(Json.toJson(Errors.NinoInvalid))
-                  case 400 if response.isInvalidPayload => BadRequest(Json.toJson(Errors.InvalidRequest))
-                  case 404 => NotFound
-                  case _ => unhandledResponse(response.status, logger)
-                }
+        } map {
+          case Left(errorResult) => handleValidationErrors(errorResult)
+          case Right((periodId, response)) =>
+            response.filter {
+              case 200 =>
+                auditPeriodicCreate(nino, sourceId, response, periodId)
+                Created.withHeaders(LOCATION -> response.createLocationHeader(nino, sourceId, periodId))
+              case 400 if response.isInvalidBusinessId => NotFound
+              case 400 if response.isInvalidPeriod =>
+                Forbidden(Json.toJson(Errors.businessError(Errors.InvalidPeriod)))
+              case 400 if response.isInvalidNino => BadRequest(Json.toJson(Errors.NinoInvalid))
+              case 400 if response.isInvalidPayload => BadRequest(Json.toJson(Errors.InvalidRequest))
+              case 404 => NotFound
+              case _ => unhandledResponse(response.status, logger)
             }
         }
       }
-  }
+    }
 
   // TODO: DES spec for this method is currently unavailable. This method should be updated once it is available.
-  def updatePeriod(nino: Nino, id: SourceId, periodId: PeriodId): Action[JsValue] = FeatureSwitch.async(parse.json) {
-    implicit request =>
+  def updatePeriod(nino: Nino, id: SourceId, periodId: PeriodId): Action[JsValue] =
+    FeatureSwitch.async(parse.json) { implicit request =>
       withAuth(nino) { implicit context =>
         validate[SelfEmploymentPeriodUpdate, SelfEmploymentPeriodResponse](request.body) { period =>
           connector.update(nino, id, periodId, period)
-        } match {
-          case Left(errorResult) => Future.successful(handleValidationErrors(errorResult))
-          case Right(result) =>
-            result.map { response =>
-              response.filter {
-                case 204 => NoContent
-                case 400 => BadRequest(Error.from(response.json))
-                case 404 => NotFound
-                case _ => unhandledResponse(response.status, logger)
-              }
+        } map {
+          case Left(errorResult) => handleValidationErrors(errorResult)
+          case Right(response) =>
+            response.filter {
+              case 204 => NoContent
+              case 400 => BadRequest(Error.from(response.json))
+              case 404 => NotFound
+              case _ => unhandledResponse(response.status, logger)
             }
         }
       }
-  }
+    }
 
-  def retrievePeriod(nino: Nino, id: SourceId, periodId: PeriodId): Action[Unit] = FeatureSwitch.async(parse.empty) {
-    implicit request =>
+  def retrievePeriod(nino: Nino, id: SourceId, periodId: PeriodId): Action[Unit] =
+    FeatureSwitch.async(parse.empty) { implicit request =>
       withAuth(nino) { implicit context =>
         periodId match {
           case Period(from, to) =>
@@ -100,26 +96,27 @@ object SelfEmploymentPeriodResource extends BaseResource {
           case _ => Future.successful(NotFound)
         }
       }
-  }
+    }
 
-  def retrievePeriods(nino: Nino, id: SourceId): Action[Unit] = FeatureSwitch.async(parse.empty) { implicit request =>
-    withAuth(nino) { implicit context =>
-      connector.getAll(nino, id).map { response =>
-        response.filter {
-          case 200 => Ok(Json.toJson(response.allPeriods))
-          case 400 => BadRequest(Error.from(response.json))
-          case 404 => NotFound
-          case _ => unhandledResponse(response.status, logger)
+  def retrievePeriods(nino: Nino, id: SourceId): Action[Unit] =
+    FeatureSwitch.async(parse.empty) { implicit request =>
+      withAuth(nino) { implicit context =>
+        connector.getAll(nino, id).map { response =>
+          response.filter {
+            case 200 => Ok(Json.toJson(response.allPeriods))
+            case 400 => BadRequest(Error.from(response.json))
+            case 404 => NotFound
+            case _ => unhandledResponse(response.status, logger)
+          }
         }
       }
     }
-  }
 
   private def auditPeriodicCreate(nino: Nino,
                                   id: SourceId,
                                   response: SelfEmploymentPeriodResponse,
                                   periodId: PeriodId)(implicit hc: HeaderCarrier, request: Request[JsValue]): Unit = {
     AuditService.audit(payload = PeriodicUpdate(nino, id, periodId, response.transactionReference, request.body),
-      "self-employment-periodic-create")
+                       "self-employment-periodic-create")
   }
 }

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentsResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentsResource.scala
@@ -27,20 +27,19 @@ import uk.gov.hmrc.selfassessmentapi.models.{Errors, _}
 import uk.gov.hmrc.selfassessmentapi.resources.wrappers.SelfEmploymentResponse
 
 import scala.concurrent.ExecutionContext.Implicits._
-import scala.concurrent.Future
 
 object SelfEmploymentsResource extends BaseResource {
   private lazy val FeatureSwitch = FeatureSwitchAction(SourceType.SelfEmployments)
   private val connector = SelfEmploymentConnector
 
-  def create(nino: Nino): Action[JsValue] = FeatureSwitch.async(parse.json) { implicit request =>
-    withAuth(nino) { implicit context =>
-      validate[SelfEmployment, SelfEmploymentResponse](request.body) { selfEmployment =>
-        connector.create(nino, Business.from(selfEmployment))
-      } match {
-        case Left(errorResult) => Future.successful(handleValidationErrors(errorResult))
-        case Right(response) =>
-          response.map { response =>
+  def create(nino: Nino): Action[JsValue] =
+    FeatureSwitch.async(parse.json) { implicit request =>
+      withAuth(nino) { implicit context =>
+        validate[SelfEmployment, SelfEmploymentResponse](request.body) { selfEmployment =>
+          connector.create(nino, Business.from(selfEmployment))
+        } map {
+          case Left(errorResult) => handleValidationErrors(errorResult)
+          case Right(response) =>
             response.filter {
               case 200 => Created.withHeaders(LOCATION -> response.createLocationHeader(nino).getOrElse(""))
               case 400 | 409 => BadRequest(Error.from(response.json))
@@ -48,60 +47,60 @@ object SelfEmploymentsResource extends BaseResource {
                 Forbidden(
                   Json.toJson(
                     Errors.businessError(Error(ErrorCode.TOO_MANY_SOURCES.toString,
-                      s"The maximum number of Self-Employment incomes sources is 1",
-                      Some("")))))
+                                               s"The maximum number of Self-Employment incomes sources is 1",
+                                               Some("")))))
               case 404 => NotFound
               case _ => unhandledResponse(response.status, logger)
             }
-          }
+        }
       }
     }
-  }
 
   // TODO: DES spec for this method is currently unavailable. This method should be updated once it is available.
-  def update(nino: Nino, id: SourceId): Action[JsValue] = FeatureSwitch.async(parse.json) { implicit request =>
-    withAuth(nino) { implicit context =>
-      validate[SelfEmploymentUpdate, SelfEmploymentResponse](request.body) { selfEmployment =>
-        connector.update(nino, des.SelfEmploymentUpdate.from(selfEmployment), id)
-      } match {
-        case Left(errorResult) => Future.successful(handleValidationErrors(errorResult))
-        case Right(result) =>
-          result.map { response =>
+  def update(nino: Nino, id: SourceId): Action[JsValue] =
+    FeatureSwitch.async(parse.json) { implicit request =>
+      withAuth(nino) { implicit context =>
+        validate[SelfEmploymentUpdate, SelfEmploymentResponse](request.body) { selfEmployment =>
+          connector.update(nino, des.SelfEmploymentUpdate.from(selfEmployment), id)
+        } map {
+          case Left(errorResult) => handleValidationErrors(errorResult)
+          case Right(response) =>
             response.filter {
               case 204 => NoContent
               case 400 => BadRequest(Error.from(response.json))
               case 404 => NotFound
               case _ => unhandledResponse(response.status, logger)
             }
+        }
+      }
+    }
+
+  def retrieve(nino: Nino, id: SourceId): Action[Unit] =
+    FeatureSwitch.async(parse.empty) { implicit request =>
+      withAuth(nino) { implicit context =>
+        connector.get(nino).map { response =>
+          response.filter {
+            case 200 => response.selfEmployment(id).map(x => Ok(Json.toJson(x))).getOrElse(NotFound)
+            case 400 if response.isInvalidNino => BadRequest(Json.toJson(Errors.NinoInvalid))
+            case 404 => NotFound
+            case _ => unhandledResponse(response.status, logger)
           }
-      }
-    }
-  }
-
-  def retrieve(nino: Nino, id: SourceId) = FeatureSwitch.async(parse.empty) { implicit request =>
-    withAuth(nino) { implicit context =>
-      connector.get(nino).map { response =>
-        response.filter {
-          case 200 => response.selfEmployment(id).map(x => Ok(Json.toJson(x))).getOrElse(NotFound)
-          case 400 if response.isInvalidNino => BadRequest(Json.toJson(Errors.NinoInvalid))
-          case 404 => NotFound
-          case _ => unhandledResponse(response.status, logger)
         }
       }
     }
-  }
 
-  def retrieveAll(nino: Nino) = FeatureSwitch.async(parse.empty) { implicit request =>
-    withAuth(nino) { implicit context =>
-      connector.get(nino).map { response =>
-        response.filter {
-          case 200 => Ok(Json.toJson(response.listSelfEmployment))
-          case 400 => BadRequest(Json.toJson(Errors.NinoInvalid))
-          case 404 => NotFound
-          case _ => unhandledResponse(response.status, logger)
+  def retrieveAll(nino: Nino): Action[Unit] =
+    FeatureSwitch.async(parse.empty) { implicit request =>
+      withAuth(nino) { implicit context =>
+        connector.get(nino).map { response =>
+          response.filter {
+            case 200 => Ok(Json.toJson(response.listSelfEmployment))
+            case 400 => BadRequest(Json.toJson(Errors.NinoInvalid))
+            case 404 => NotFound
+            case _ => unhandledResponse(response.status, logger)
+          }
         }
       }
     }
-  }
 
 }

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/TaxCalculationResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/TaxCalculationResource.scala
@@ -21,7 +21,6 @@ import play.api.mvc.{Action, Request}
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.selfassessmentapi.connectors.TaxCalculationConnector
-import uk.gov.hmrc.selfassessmentapi.models.Errors.Error
 import uk.gov.hmrc.selfassessmentapi.models.audit.{TaxCalculationRequest, TaxCalculationTrigger}
 import uk.gov.hmrc.selfassessmentapi.models.calculation.CalculationRequest
 import uk.gov.hmrc.selfassessmentapi.models.{Errors, SourceId, SourceType}
@@ -29,7 +28,6 @@ import uk.gov.hmrc.selfassessmentapi.resources.wrappers.TaxCalculationResponse
 import uk.gov.hmrc.selfassessmentapi.services.AuditService
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
 
 object TaxCalculationResource extends BaseResource {
 
@@ -43,54 +41,58 @@ object TaxCalculationResource extends BaseResource {
        |}
      """.stripMargin
 
-  def requestCalculation(nino: Nino): Action[JsValue] = FeatureSwitch.async(parse.json) { implicit request =>
-    withAuth(nino) { implicit context =>
-      validate[CalculationRequest, TaxCalculationResponse](request.body) { req =>
-        connector.requestCalculation(nino, req.taxYear)
-      } match {
-        case Left(errorResult) => Future.successful(handleValidationErrors(errorResult))
-        case Right(result) => result.map { response =>
+  def requestCalculation(nino: Nino): Action[JsValue] =
+    FeatureSwitch.async(parse.json) { implicit request =>
+      withAuth(nino) { implicit context =>
+        validate[CalculationRequest, TaxCalculationResponse](request.body) { req =>
+          connector.requestCalculation(nino, req.taxYear)
+        } map {
+          case Left(errorResult) => handleValidationErrors(errorResult)
+          case Right(response) =>
+            response.filter {
+              case 202 =>
+                auditTaxCalcTrigger(nino, response)
+                Accepted(Json.parse(cannedEtaResponse))
+                  .withHeaders(
+                    LOCATION -> response.calcId
+                      .map(id => s"/self-assessment/ni/$nino/calculations/$id")
+                      .getOrElse(""))
+              case 400 if response.isInvalidNino => BadRequest(Json.toJson(Errors.NinoInvalid))
+              case _ => unhandledResponse(response.status, logger)
+            }
+        }
+      }
+    }
+
+  def retrieveCalculation(nino: Nino, calcId: SourceId): Action[Unit] =
+    FeatureSwitch.async(parse.empty) { implicit request =>
+      withAuth(nino) { implicit context =>
+        connector.retrieveCalculation(nino, calcId).map { response =>
           response.filter {
-            case 202 =>
-              auditTaxCalcTrigger(nino, response)
-              Accepted(Json.parse(cannedEtaResponse))
-                .withHeaders(LOCATION -> response.calcId.map(id => s"/self-assessment/ni/$nino/calculations/$id").getOrElse(""))
-            case 400 if response.isInvalidNino => BadRequest(Json.toJson(Errors.NinoInvalid))
+            case 200 =>
+              auditTaxCalcRequest(nino, calcId, response)
+              Ok(Json.toJson(response.calculation))
+            case 204 => NoContent
+            case 400 if response.isInvalidCalcId => NotFound
+            case 400 if response.isInvalidIdentifier => BadRequest(Json.toJson(Errors.NinoInvalid))
+            case 404 => NotFound
             case _ => unhandledResponse(response.status, logger)
           }
         }
       }
     }
+
+  private def auditTaxCalcTrigger(nino: Nino, response: TaxCalculationResponse)(implicit hc: HeaderCarrier,
+                                                                                request: Request[JsValue]): Unit = {
+    AuditService.audit(payload = TaxCalculationTrigger(nino,
+                                                       request.body.as[CalculationRequest].taxYear,
+                                                       response.calcId.getOrElse("")),
+                       "trigger-tax-calculation")
   }
 
-  def retrieveCalculation(nino: Nino, calcId: SourceId): Action[Unit] = FeatureSwitch.async(parse.empty) { implicit request =>
-    withAuth(nino) { implicit context =>
-      connector.retrieveCalculation(nino, calcId).map { response =>
-        response.filter {
-          case 200 =>
-            auditTaxCalcRequest(nino, calcId, response)
-            Ok(Json.toJson(response.calculation))
-          case 204 => NoContent
-          case 400 if response.isInvalidCalcId => NotFound
-          case 400 if response.isInvalidIdentifier => BadRequest(Json.toJson(Errors.NinoInvalid))
-          case 404 => NotFound
-          case _ => unhandledResponse(response.status, logger)
-        }
-      }
-    }
-  }
-
-  private def auditTaxCalcTrigger(nino: Nino, response: TaxCalculationResponse)
-                                 (implicit hc: HeaderCarrier, request: Request[JsValue]): Unit = {
-    AuditService.audit(
-      payload = TaxCalculationTrigger(nino, request.body.as[CalculationRequest].taxYear, response.calcId.getOrElse("")),
-      "trigger-tax-calculation")
-  }
-
-  private def auditTaxCalcRequest(nino: Nino, calcId: String, response: TaxCalculationResponse)
-                                 (implicit hc: HeaderCarrier, request: Request[_]): Unit = {
-    AuditService.audit(
-      payload = TaxCalculationRequest(nino, calcId, response.json),
-      "retrieve-tax-calculation")
+  private def auditTaxCalcRequest(nino: Nino, calcId: String, response: TaxCalculationResponse)(
+      implicit hc: HeaderCarrier,
+      request: Request[_]): Unit = {
+    AuditService.audit(payload = TaxCalculationRequest(nino, calcId, response.json), "retrieve-tax-calculation")
   }
 }

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/wrappers/Response.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/wrappers/Response.scala
@@ -25,7 +25,7 @@ import uk.gov.hmrc.selfassessmentapi.contexts.AuthContext
 import uk.gov.hmrc.selfassessmentapi.models.Errors
 
 trait Response {
-  val logger: Logger = Logger(classOf[Response])
+  val logger: Logger = Logger(this.getClass)
 
   def underlying: HttpResponse
 


### PR DESCRIPTION
- Controllers were calling `validate` which returned a blocking call of type Either[E, Future[A]]. 
 Refactored to return Future[Either[E, A]].

- Use correct mixed-in class when logging DES response.



