### PR TITLE
[MTDSA-1021] Update URL to match the DES spec for retrieve all property periods.

### DIFF
--- a/app/uk/gov/hmrc/selfassessmentapi/connectors/PropertiesPeriodConnector.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/connectors/PropertiesPeriodConnector.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.selfassessmentapi.connectors
 
+import org.joda.time.LocalDate
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.selfassessmentapi.config.AppContext
@@ -71,15 +72,15 @@ object PropertiesPeriodConnector {
         PropertiesPeriodResponse)
   }
 
-  def retrieve(nino: Nino, periodId: PeriodId, propertyType: PropertyType)(
+  def retrieve(nino: Nino, from: LocalDate, to: LocalDate, propertyType: PropertyType)(
       implicit hc: HeaderCarrier): Future[PropertiesPeriodResponse] =
     httpGet[PropertiesPeriodResponse](
-      baseUrl + s"/income-store/nino/$nino/uk-properties/$propertyType/periodic-summaries/$periodId",
+      baseUrl + s"/income-store/nino/$nino/uk-properties/$propertyType/periodic-summaries?from=$from&to=$to",
       PropertiesPeriodResponse)
 
   def retrieveAll(nino: Nino, propertyType: PropertyType)(
       implicit hc: HeaderCarrier): Future[PropertiesPeriodResponse] =
     httpGet[PropertiesPeriodResponse](
-      baseUrl + s"/income-store/nino/$nino/uk-properties/$propertyType/periodic-summaries",
+      baseUrl + s"/income-store/nino/$nino/uk-properties/$propertyType/periodicsummaries",
       PropertiesPeriodResponse)
 }

--- a/app/uk/gov/hmrc/selfassessmentapi/models/Period.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/models/Period.scala
@@ -24,7 +24,7 @@ trait Period {
   val from: LocalDate
   val to: LocalDate
 
-  def createPeriodId = s"${from}_$to"
+  def periodId = s"${from}_$to"
 }
 
 object Period {
@@ -33,9 +33,9 @@ object Period {
   def unapply(period: String): Option[(LocalDate, LocalDate)] = {
     period match {
       case periodPattern(from, to) =>
-        Try(Some((new LocalDate(from), new LocalDate(to)))) match {
+        Try(Some((LocalDate.parse(from), LocalDate.parse(to)))) match {
           case Success(x) => x
-          case Failure(e) => None
+          case Failure(_) => None
         }
       case _ => None
     }

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentPeriodResource.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/SelfEmploymentPeriodResource.scala
@@ -41,7 +41,7 @@ object SelfEmploymentPeriodResource extends BaseResource {
         validate[SelfEmploymentPeriod, (PeriodId, SelfEmploymentPeriodResponse)](request.body) { period =>
           connector
             .create(nino, sourceId, period)
-            .map((period.createPeriodId, _))
+            .map((period.periodId, _))
         } map {
           case Left(errorResult) => handleValidationErrors(errorResult)
           case Right((periodId, response)) =>

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/wrappers/PropertiesPeriodResponse.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/wrappers/PropertiesPeriodResponse.scala
@@ -96,7 +96,7 @@ trait ResponseMapper[P <: Period, D <: des.properties.Period] {
     response.underlying.json.asOpt[Seq[D]] match {
       case Some(desPeriods) =>
         val asSummary = PeriodMapper[P, D].asSummary _
-        val setId = (p: P) => PeriodMapper[P, D].setId(p, Some(p.createPeriodId))
+        val setId = (p: P) => PeriodMapper[P, D].setId(p, Some(p.periodId))
         val from = PeriodMapper[P, D].from _
         val fromDES = from andThen setId andThen asSummary
         desPeriods.map(fromDES(_)).sorted

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/wrappers/SelfEmploymentPeriodResponse.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/wrappers/SelfEmploymentPeriodResponse.scala
@@ -41,7 +41,7 @@ case class SelfEmploymentPeriodResponse(underlying: HttpResponse) extends Respon
     json.asOpt[Seq[des.SelfEmploymentPeriod]] match {
       case Some(desPeriods) =>
         val from = SelfEmploymentPeriod.from _
-        val setId = (p: SelfEmploymentPeriod) => p.copy(id = Some(p.createPeriodId))
+        val setId = (p: SelfEmploymentPeriod) => p.copy(id = Some(p.periodId))
         val fromDES = from andThen setId andThen (_.asSummary)
         desPeriods.map(fromDES).sorted
       case None =>

--- a/func/uk/gov/hmrc/selfassessmentapi/resources/PropertiesPeriodResourceSpec.scala
+++ b/func/uk/gov/hmrc/selfassessmentapi/resources/PropertiesPeriodResourceSpec.scala
@@ -257,7 +257,7 @@ class PropertiesPeriodResourceSpec extends BaseFunctionalSpec {
           .properties
           .periodWillBeReturnedFor(nino, propertyType)
           .when()
-          .get(s"/ni/$nino/uk-properties/$propertyType/periods/def")
+          .get(s"/ni/$nino/uk-properties/$propertyType/periods/2017-04-06_2018-04-05")
           .thenAssertThat()
           .statusIs(200)
           .contentTypeIsJson()
@@ -273,7 +273,7 @@ class PropertiesPeriodResourceSpec extends BaseFunctionalSpec {
           .properties
           .noPeriodFor(nino, propertyType)
           .when()
-          .get(s"/ni/$nino/uk-properties/$propertyType/periods/def")
+          .get(s"/ni/$nino/uk-properties/$propertyType/periods/2017-04-06_2018-04-05")
           .thenAssertThat()
           .statusIs(404)
       }
@@ -285,7 +285,7 @@ class PropertiesPeriodResourceSpec extends BaseFunctionalSpec {
           .des()
           .isATeapotFor(nino)
           .when()
-          .get(s"/ni/$nino/uk-properties/$propertyType/periods/def")
+          .get(s"/ni/$nino/uk-properties/$propertyType/periods/2017-04-06_2018-04-05")
           .thenAssertThat()
           .statusIs(500)
       }

--- a/func/uk/gov/hmrc/support/BaseFunctionalSpec.scala
+++ b/func/uk/gov/hmrc/support/BaseFunctionalSpec.scala
@@ -11,7 +11,7 @@ import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.play.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.selfassessmentapi.models.properties.PropertyType
 import uk.gov.hmrc.selfassessmentapi.models.properties.PropertyType.PropertyType
-import uk.gov.hmrc.selfassessmentapi.models.{ErrorNotImplemented, TaxYear}
+import uk.gov.hmrc.selfassessmentapi.models.{ErrorNotImplemented, Period, TaxYear}
 import uk.gov.hmrc.selfassessmentapi.resources.DesJsons
 import uk.gov.hmrc.selfassessmentapi.{NinoGenerator, TestApplication}
 
@@ -1151,7 +1151,7 @@ trait BaseFunctionalSpec extends TestApplication {
           givens
         }
 
-        def periodWillBeReturnedFor(nino: Nino, propertyType: PropertyType, periodId: String = "def"): Givens = {
+        def periodWillBeReturnedFor(nino: Nino, propertyType: PropertyType, periodId: String = "2017-04-06_2018-04-05"): Givens = {
           val periodAsJsonString = propertyType match {
             case PropertyType.FHL =>
               DesJsons.Properties
@@ -1181,15 +1181,19 @@ trait BaseFunctionalSpec extends TestApplication {
                              other = Some(200.00))
                 .toString()
           }
-          stubFor(
-            get(urlEqualTo(s"/income-store/nino/$nino/uk-properties/$propertyType/periodic-summaries/$periodId"))
-              .willReturn(
-                aResponse()
-                  .withStatus(200)
-                  .withHeader("Content-Type", "application/json")
-                  .withBody(periodAsJsonString)))
 
-          givens
+          periodId match {
+            case Period(from, to) =>
+              stubFor(
+                get(urlEqualTo(s"/income-store/nino/$nino/uk-properties/$propertyType/periodic-summaries?from=$from&to=$to"))
+                  .willReturn(
+                    aResponse()
+                      .withStatus(200)
+                      .withHeader("Content-Type", "application/json")
+                      .withBody(periodAsJsonString)))
+              givens
+            case _ => fail(s"Invalid period ID: $periodId.")
+          }
         }
 
         def periodWillBeNotBeCreatedForInexistentIncomeSource(nino: Nino, propertyType: PropertyType): Givens = {
@@ -1206,7 +1210,7 @@ trait BaseFunctionalSpec extends TestApplication {
 
         def periodsWillBeReturnedFor(nino: Nino, propertyType: PropertyType): Givens = {
           stubFor(
-            get(urlEqualTo(s"/income-store/nino/$nino/uk-properties/$propertyType/periodic-summaries"))
+            get(urlEqualTo(s"/income-store/nino/$nino/uk-properties/$propertyType/periodicsummaries"))
               .willReturn(
                 aResponse()
                   .withStatus(200)
@@ -1216,21 +1220,24 @@ trait BaseFunctionalSpec extends TestApplication {
           givens
         }
 
-        def noPeriodFor(nino: Nino, propertyType: PropertyType, periodId: String = "def"): Givens = {
-          stubFor(
-            get(urlEqualTo(s"/income-store/nino/$nino/uk-properties/$propertyType/periodic-summaries/$periodId"))
-              .willReturn(
-                aResponse()
-                  .withStatus(404)
-                  .withHeader("Content-Type", "application/json")
-                  .withBody(DesJsons.Errors.ninoNotFound)))
-
-          givens
+        def noPeriodFor(nino: Nino, propertyType: PropertyType, periodId: String = "2017-04-06_2018-04-05"): Givens = {
+          periodId match {
+            case Period(from, to) =>
+              stubFor(
+                get(urlEqualTo(s"/income-store/nino/$nino/uk-properties/$propertyType/periodic-summaries?from=$from&to=$to"))
+                  .willReturn(
+                    aResponse()
+                      .withStatus(404)
+                      .withHeader("Content-Type", "application/json")
+                      .withBody(DesJsons.Errors.ninoNotFound)))
+              givens
+            case _ => fail(s"Invalid period ID: $periodId.")
+          }
         }
 
         def noPeriodsFor(nino: Nino, propertyType: PropertyType): Givens = {
           stubFor(
-            get(urlEqualTo(s"/income-store/nino/$nino/uk-properties/$propertyType/periodic-summaries"))
+            get(urlEqualTo(s"/income-store/nino/$nino/uk-properties/$propertyType/periodicsummaries"))
               .willReturn(
                 aResponse()
                   .withStatus(200)
@@ -1242,7 +1249,7 @@ trait BaseFunctionalSpec extends TestApplication {
 
         def doesNotExistPeriodFor(nino: Nino, propertyType: PropertyType): Givens = {
           stubFor(
-            get(urlEqualTo(s"/income-store/nino/$nino/uk-properties/$propertyType/periodic-summaries"))
+            get(urlEqualTo(s"/income-store/nino/$nino/uk-properties/$propertyType/periodicsummaries"))
               .willReturn(
                 aResponse()
                   .withStatus(404)

--- a/test/uk/gov/hmrc/selfassessmentapi/models/PeriodSpec.scala
+++ b/test/uk/gov/hmrc/selfassessmentapi/models/PeriodSpec.scala
@@ -25,7 +25,7 @@ class PeriodSpec extends UnitSpec {
       (new Period {
         override val from: LocalDate = LocalDate.parse("2017-04-07")
         override val to: LocalDate = LocalDate.parse("2018-04-07")
-      } createPeriodId) shouldBe "2017-04-07_2018-04-07"
+      } periodId) shouldBe "2017-04-07_2018-04-07"
     }
   }
 }


### PR DESCRIPTION
- Update tests to match this new URL.

- Update URL for retrieve all property periods.

We have had to modify the URL of this endpoint on the DES simulator in
order to avoid a naming conflict.

As this endpoint is currently test-only this will have no impact on any
production release.