### PR TITLE
Minor code cleanup.

### DIFF
--- a/app/uk/gov/hmrc/selfassessmentapi/resources/wrappers/BusinessDetailsResponse.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/wrappers/BusinessDetailsResponse.scala
@@ -20,11 +20,12 @@ import uk.gov.hmrc.play.http.HttpResponse
 import uk.gov.hmrc.selfassessmentapi.models.MtdId
 
 case class BusinessDetailsResponse(underlying: HttpResponse) extends Response {
-  def mtdId: Option[MtdId] = {
-    if (status == 200) (json \ "mtdbsa").asOpt[String].map(MtdId(_))
-    else {
-      logger.error(s"The response from DES does not match the expected format. JSON: [$json]")
-      None
+  def mtdId: Option[MtdId] =
+    (json \ "mtdbsa").asOpt[String] match {
+      case Some(id) =>
+        Some(MtdId(id))
+      case None =>
+        logger.error(s"The response from DES does not match the expected format. JSON: [$json]")
+        None
     }
-  }
 }

--- a/app/uk/gov/hmrc/selfassessmentapi/resources/wrappers/PropertiesAnnualSummaryResponse.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/wrappers/PropertiesAnnualSummaryResponse.scala
@@ -31,26 +31,20 @@ case class PropertiesAnnualSummaryResponse(propertyType: PropertyType, underlyin
     case PropertyType.OTHER =>
       json.asOpt[des.OtherPropertiesAnnualSummary] match {
         case Some(other) =>
-          Some(
-            OtherPropertiesAnnualSummary.from(
-              des.OtherPropertiesAnnualSummary(other.annualAllowances, other.annualAdjustments)))
-        case None => {
+          Some(OtherPropertiesAnnualSummary.from(other))
+        case None =>
           logger.error(
             s"The response from DES does not match the expected format. PropertyType: [$propertyType] JSON: [$json]")
           None
-        }
       }
     case PropertyType.FHL =>
       json.asOpt[des.FHLPropertiesAnnualSummary] match {
         case Some(fhl) =>
-          Some(
-            FHLPropertiesAnnualSummary.from(
-              des.FHLPropertiesAnnualSummary(fhl.annualAllowances, fhl.annualAdjustments)))
-        case None => {
+          Some(FHLPropertiesAnnualSummary.from(fhl))
+        case None =>
           logger.error(
             s"The response from DES does not match the expected format. PropertyType: [$propertyType] JSON: [$json]")
           None
-        }
       }
   }
 


### PR DESCRIPTION
- Remove unnecessary copying of objects.
- Replace 'instance-of' style matching with unapply matching.