### PR TITLE
[MTDSA-1121] Fix validations Self-Employment incomes and expenses

### DIFF
--- a/app/uk/gov/hmrc/selfassessmentapi/models/selfemployment/Expenses.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/models/selfemployment/Expenses.scala
@@ -59,5 +59,5 @@ object Expenses {
     .filter(
       ValidationError("the disallowableAmount for depreciation expenses must be the same as the amount",
                       ErrorCode.DEPRECIATION_DISALLOWABLE_AMOUNT)
-    )(_.depreciation.forall(e => e.amount == e.disallowableAmount.getOrElse(false)))
+    )(_.depreciation.forall(e => e.disallowableAmount.forall(_ == e.amount)))
 }

--- a/test/uk/gov/hmrc/selfassessmentapi/models/selfemployment/ExpensesSpec.scala
+++ b/test/uk/gov/hmrc/selfassessmentapi/models/selfemployment/ExpensesSpec.scala
@@ -31,6 +31,9 @@ class ExpensesSpec extends JsonSpec {
                                              badDebt = Some(Expense(200, Some(100)))),
                                     "",
                                     ErrorCode.DEPRECIATION_DISALLOWABLE_AMOUNT)
+
+    "accept Expenses with depreciation expense where disallowable amount is not defined" in
+      roundTripJson(Expenses(depreciation = Some(Expense(200, None))))
   }
 
 }

--- a/test/uk/gov/hmrc/selfassessmentapi/models/selfemployment/IncomesSpec.scala
+++ b/test/uk/gov/hmrc/selfassessmentapi/models/selfemployment/IncomesSpec.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.selfassessmentapi.models.selfemployment
+
+import uk.gov.hmrc.selfassessmentapi.models.SimpleIncome
+import uk.gov.hmrc.selfassessmentapi.resources.JsonSpec
+
+class IncomesSpec extends JsonSpec {
+  "Incomes" should {
+    "round trip in" in
+      roundTripJson(Incomes(turnover = Some(SimpleIncome(200)), other = Some(SimpleIncome(200))))
+
+    "accept Incomes with just 'turnover' defined" in
+      roundTripJson(Incomes(turnover = Some(SimpleIncome(200))))
+
+    "accept Incomes with just 'other' defined" in
+      roundTripJson(Incomes(other = Some(SimpleIncome(200))))
+  }
+}


### PR DESCRIPTION
- When third-party developers submit either of `turnover` or `other` fields in Self-Employment incomes the DES-simulation implementation was incorrectly returning a validation error.  Both fields should be optional as per the DES API 29 spec

- Fix disallowable amount validation in Expenses