### PR TITLE
[fix-SEObligations] filter out EOPS obligations from standard eops response

### DIFF
--- a/app/uk/gov/hmrc/selfassessmentapi/resources/wrappers/ObligationsResponse.scala
+++ b/app/uk/gov/hmrc/selfassessmentapi/resources/wrappers/ObligationsResponse.scala
@@ -41,7 +41,7 @@ case class ObligationsResponse(underlying: HttpResponse) extends Response {
         else
           obl.identification.exists(identification => identification.incomeSourceType.contains(incomeSourceType))
         if check
-        detail <- obl.obligationDetails
+        detail <- obl.obligationDetails.filterNot(_.periodKey.contains("EOPS"))
       } yield DesTransformValidator[ObligationDetail, Obligation].from(detail)
 
       result.find(_.isLeft) match {


### PR DESCRIPTION
Please check if this change includes (or even requires) the following:

 - [ ] unit tests
 - [ ] functional tests
 - [ ] audit events
 - [ ] RAML documentation
 - [ ] logging