### PR TITLE
Removed defunct travisci build badge and link from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Self Assessment API
-[![Build Status](https://travis-ci.org/hmrc/self-assessment-api.svg)](https://travis-ci.org/hmrc/self-assessment-api) [ ![Download](https://api.bintray.com/packages/hmrc/releases/self-assessment-api/images/download.svg) ](https://bintray.com/hmrc/releases/self-assessment-api/_latestVersion)
+[ ![Download](https://api.bintray.com/packages/hmrc/releases/self-assessment-api/images/download.svg) ](https://bintray.com/hmrc/releases/self-assessment-api/_latestVersion)
 
 This API provides access to versioned resources of the [Self Assessment API Legacy](https://github.com/hmrc/self-assessment-api-legacy).
 


### PR DESCRIPTION
This repo appears to have ceased using travis-ci for builds around April 2019 and I suspect this readme change was missed in that update.

"Since June 15th, 2021, the building on travis-ci.org is ceased." as stated on travis-ci.org when one follows the badge link https://travis-ci.org/github/hmrc/self-assessment-api
